### PR TITLE
Setup Links to open in a separate window

### DIFF
--- a/src/views/components/shared/project.html
+++ b/src/views/components/shared/project.html
@@ -6,7 +6,7 @@
 			<div class="row">
 				<div class="col-sm-7">
 					<div class="project-github">
-						{{#if github}}<a href="{{github}}"><i class="fa fa-github"></i>{{author}}</a>{{else}}{{author}}{{/if github}}
+						{{#if github}}<a href="{{github}}" target="_blank"><i class="fa fa-github"></i>{{author}}</a>{{else}}{{author}}{{/if github}}
 					</div>
 
 					<div class="project-name">
@@ -28,8 +28,8 @@
 							<i class="fa {{~getCollectionIndex(collection, name) ? 'fa-check-circle' : 'fa-plus-circle' }}"></i>
 						</button>
 
-						<a class="btn btn-default btn-icon" href="{{apiRoot}}/jsdelivr/libraries?name={{name}}" decorator="tooltip: API"><i class="fa fa-cog"></i></a>
-						<a class="btn btn-default btn-icon" href="{{homepage}}" decorator="tooltip: Homepage"><i class="fa fa-link"></i></a>
+						<a class="btn btn-default btn-icon" href="{{apiRoot}}/jsdelivr/libraries?name={{name}}" target="_blank" decorator="tooltip: API"><i class="fa fa-cog"></i></a>
+						<a class="btn btn-default btn-icon" href="{{homepage}}" target="_blank" decorator="tooltip: Homepage"><i class="fa fa-link"></i></a>
 					</div>
 				</div>
 			</div>
@@ -43,7 +43,7 @@
 
 				<div class="col-xs-10">
 					<div class="project-files-header-link">
-						mainfile: <a href="{{cdnRoot}}/{{name}}/{{selectedVersion}}/{{mainfile}}"><i class="fa fa-file-text-o"></i>{{mainfile}}</a>
+						mainfile: <a href="{{cdnRoot}}/{{name}}/{{selectedVersion}}/{{mainfile}}" target="_blank"><i class="fa fa-file-text-o"></i>{{mainfile}}</a>
 					</div>
 
 					<div class="project-files-header-link">


### PR DESCRIPTION
Setup Links to open in a separate window instead of self
Added `target="_blank"` to:
1. Github Repo Name
2. Mainfile Link
3. API Link
4. Repo Homepage Link