### PR TITLE
feat(search): no longer manually concatenate name

### DIFF
--- a/src/public/js/utils/search.js
+++ b/src/public/js/utils/search.js
@@ -8,7 +8,6 @@ module.exports = (queryString, page = 0, hitsPerPage = 10) => {
 		let options = {
 			page,
 			hitsPerPage,
-			optionalFacetFilters: `concatenatedName:${parsed.query.replace(/[-/@_.]+/g, '')}`,
 			attributesToHighlight: [],
 			attributesToRetrieve: [ 'deprecated', 'description', 'githubRepo', 'homepage', 'keywords', 'license', 'name', 'owner', 'version' ],
 		};


### PR DESCRIPTION
Hey! 

I just enabled this with a query rule on the index instead, now automatically, when there's a match with any of the concatenated names, it will be boosted as an optionalFilter. 

This means that the configuration doesn't need to be done on your side anymore. You should see the exact same results after merging this PR

<img width="588" alt="screen shot 2017-09-22 at 10 23 00" src="https://user-images.githubusercontent.com/6270048/30735812-a1a48daa-9f80-11e7-850d-3bd26d368897.png">
