### PR TITLE
tabular numbers in home screen stats

### DIFF
--- a/src/public/less/components/landing-bottom.less
+++ b/src/public/less/components/landing-bottom.less
@@ -75,6 +75,7 @@
 			background-color: @c-orange-bg;
 			padding: 5px 30px;
 			border-radius: 35px;
+			font-feature-settings: 'tnum';
 		}
 
 		.since {


### PR DESCRIPTION
This looks really pleasing: 

Before:

![2018-02-12 16_39_26](https://user-images.githubusercontent.com/6270048/36105181-490f126e-1014-11e8-8d2f-3d9e85039ab0.gif)


After: 

![2018-02-12 16_41_44](https://user-images.githubusercontent.com/6270048/36105170-43703eaa-1014-11e8-85a4-b39ccc1148c1.gif)
