### PR TITLE
+ package.json `browser` priority

### DIFF
--- a/src/views/pages/features.html
+++ b/src/views/pages/features.html
@@ -288,7 +288,7 @@
 							For packages hosted on npm, we support setting a "default" file for each package.
 							This file is displayed at the top of directory listings on our website and available under shorter URL on the CDN.
 
-							The default file can be configured by setting one of the following fields in <code>package.json</code>, with <code>jsdelivr</code> having the highest priority:
+							The default file can be configured by setting one of the following fields in <code>package.json</code>, with <code>jsdelivr</code> having the highest priority and <code>browser</code> is chosen over <code>main</code>:
 						</p>
 
 						<ul>

--- a/src/views/pages/features.html
+++ b/src/views/pages/features.html
@@ -288,14 +288,14 @@
 							For packages hosted on npm, we support setting a "default" file for each package.
 							This file is displayed at the top of directory listings on our website and available under shorter URL on the CDN.
 
-							The default file can be configured by setting one of the following fields in <code>package.json</code>, with <code>jsdelivr</code> having the highest priority and <code>browser</code> is chosen over <code>main</code>:
+							The default file can be configured by setting one of the following fields in <code>package.json</code> (ordered by priority):
 						</p>
 
-						<ul>
+						<ol>
 							<li><code>jsdelivr</code></li>
 							<li><code>browser</code></li>
 							<li><code>main</code></li>
-						</ul>
+						</ol>
 					</section>
 				</div>
 


### PR DESCRIPTION
Am I assuming this correct?

Having a more general `browser` field in `package.json` may be more desirable for some package maintainers than `jsdelivr`.