### PR TITLE
feat(search): add analytics tag to main search

### DIFF
--- a/src/public/js/utils/search.js
+++ b/src/public/js/utils/search.js
@@ -10,7 +10,7 @@ module.exports = (queryString, page = 0, hitsPerPage = 10) => {
 			hitsPerPage,
 			attributesToHighlight: [],
 			attributesToRetrieve: [ 'deprecated', 'description', 'githubRepo', 'homepage', 'keywords', 'license', 'name', 'owner', 'version' ],
-			analyticsTags: ['jsdelivr'],
+			analyticsTags: [ 'jsdelivr' ],
 		};
 
 		if (parsed.facetFilters) {

--- a/src/public/js/utils/search.js
+++ b/src/public/js/utils/search.js
@@ -10,6 +10,7 @@ module.exports = (queryString, page = 0, hitsPerPage = 10) => {
 			hitsPerPage,
 			attributesToHighlight: [],
 			attributesToRetrieve: [ 'deprecated', 'description', 'githubRepo', 'homepage', 'keywords', 'license', 'name', 'owner', 'version' ],
+			analyticsTags: ['jsdelivr'],
 		};
 
 		if (parsed.facetFilters) {


### PR DESCRIPTION
This will cause the analytics to be more relevant, because we will be able to filter to the searches only for jsDelivr