### PR TITLE
Update Cloudflare Data Center Map

### DIFF
--- a/src/public/js/map/map.json
+++ b/src/public/js/map/map.json
@@ -1,653 +1,888 @@
 [
 	{
-		"title": "Cloudflare - Amsterdam",
-		"latitude": 52.2452157,
-		"longitude": 4.645167900000001
-	},
-	{
-		"title": "Cloudflare - Ashburn",
-		"latitude": 38.9187567,
-		"longitude": -77.7374416
-	},
-	{
-		"title": "Cloudflare - Athens",
-		"latitude": 37.9838096,
-		"longitude": 23.7275388
-	},
-	{
-		"title": "Cloudflare - Atlanta",
-		"latitude": 33.6239954,
-		"longitude": -84.8879824
-	},
-	{
-		"title": "Cloudflare - Auckland",
-		"latitude": -36.8484597,
-		"longitude": 174.5133315
-	},
-	{
-		"title": "Cloudflare - Baghdad",
-		"latitude": 33.3128057,
-		"longitude": 44.3614875
-	},
-	{
-		"title": "Cloudflare - Bangkok",
-		"latitude": 13.7563309,
-		"longitude": 100.2517651
-	},
-	{
-		"title": "Cloudflare - Barcelona",
-		"latitude": 41.3850639,
-		"longitude": 2.1734035
-	},
-	{
-		"title": "Cloudflare - Beirut",
-		"latitude": 33.8937913,
-		"longitude": 35.5017767
-	},
-	{
-		"title": "Cloudflare - Belgrade",
-		"latitude": 44.786568,
-		"longitude": 20.4489216
-	},
-	{
-		"title": "Cloudflare - Berlin",
-		"latitude": 52.52000659999999,
-		"longitude": 13.404954
-	},
-	{
-		"title": "Cloudflare - Bogota",
-		"latitude": 4.710988599999999,
-		"longitude": -74.072092
-	},
-	{
-		"title": "Cloudflare - Boston",
-		"latitude": 42.3600825,
-		"longitude": -71.3088801
-	},
-	{
-		"title": "Cloudflare - Brisbane",
-		"latitude": -27.4697707,
-		"longitude": 152.7751235
-	},
-	{
-		"title": "Cloudflare - Brussels",
-		"latitude": 50.8503463,
-		"longitude": 4.3517211
-	},
-	{
-		"title": "Cloudflare - Bucharest",
-		"latitude": 44.4267674,
-		"longitude": 26.1025384
-	},
-	{
-		"title": "Cloudflare - Budapest",
-		"latitude": 47.497912,
-		"longitude": 19.040235
-	},
-	{
-		"title": "Cloudflare - Buenos Aires",
-		"latitude": -34.6036844,
-		"longitude": -58.6315591
-	},
-	{
-		"title": "Cloudflare - Cairo",
-		"latitude": 30.0444196,
-		"longitude": 31.2357116
-	},
-	{
-		"title": "Cloudflare - Calgary",
-		"latitude": 51.0486151,
-		"longitude": -114.0708459
-	},
-	{
-		"title": "Cloudflare - Cape Town",
-		"latitude": -33.9248685,
-		"longitude": 18.1740553
-	},
-	{
-		"title": "Cloudflare - Cebu City",
-		"latitude": 10.3156992,
-		"longitude": 123.8854366
-	},
-	{
-		"title": "Cloudflare - Chennai",
-		"latitude": 13.0826802,
-		"longitude": 80.0207184
-	},
-	{
-		"title": "Cloudflare - Chișinău",
-		"latitude": 47.0104529,
-		"longitude": 28.8638102
-	},
-	{
-		"title": "Cloudflare - Chicago",
-		"latitude": 41.7531136,
-		"longitude": -88.1297982
-	},
-	{
-		"title": "Cloudflare - Colombo",
-		"latitude": 6.9270786,
-		"longitude": 79.861243
-	},
-	{
-		"title": "Cloudflare - Copenhagen",
-		"latitude": 55.6760968,
-		"longitude": 12.5683372
-	},
-	{
-		"title": "Cloudflare - Dallas",
-		"latitude": 32.6516642,
-		"longitude": -97.04698789999999
-	},
-	{
-		"title": "Cloudflare - Denver",
-		"latitude": 39.7392358,
-		"longitude": -105.240251
-	},
-	{
-		"title": "Cloudflare - Detroit",
-		"latitude": 42.331427,
-		"longitude": -83.0457538
-	},
-	{
-		"title": "Cloudflare - Djibouti",
-		"latitude": 11.825138,
-		"longitude": 42.590275
-	},
-	{
-		"title": "Cloudflare - Doha",
-		"latitude": 25.2854473,
-		"longitude": 51.53103979999999
-	},
-	{
-		"title": "Cloudflare - Dubai",
-		"latitude": 25.2048493,
-		"longitude": 55.0207828
-	},
-	{
-		"title": "Cloudflare - Dublin",
-		"latitude": 53.3498053,
-		"longitude": -6.2603097
-	},
-	{
-		"title": "Cloudflare - Durban",
-		"latitude": -29.85868039999999,
-		"longitude": 31.0218404
-	},
-	{
-		"title": "Cloudflare - Düsseldorf",
-		"latitude": 51.2277411,
-		"longitude": 6.7734556
-	},
-	{
-		"title": "Cloudflare - Edinburgh",
-		"latitude": 55.953252,
-		"longitude": -3.188267
-	},
-	{
-		"title": "Cloudflare - Frankfurt",
-		"latitude": 49.9859221,
-		"longitude": 8.1821267
-	},
-	{
-		"title": "Cloudflare - Hamburg",
-		"latitude": 53.5510846,
-		"longitude": 9.9936819
-	},
-	{
-		"title": "Cloudflare - Helsinki",
-		"latitude": 60.16985569999999,
-		"longitude": 24.9383791
-	},
-	{
-		"title": "Cloudflare - Hong Kong",
-		"latitude": 22.271428,
-		"longitude": 113.859497
-	},
-	{
-		"title": "Cloudflare - Houston",
-		"latitude": 29.7604267,
-		"longitude": -95.6198028
-	},
-	{
-		"title": "Cloudflare - Indianapolis",
-		"latitude": 39.768403,
-		"longitude": -86.158068
-	},
-	{
-		"title": "Cloudflare - Istanbul",
-		"latitude": 41.0082376,
-		"longitude": 28.9783589
-	},
-	{
-		"title": "Cloudflare - Jacksonville",
-		"latitude": 30.3321838,
-		"longitude": -81.65565099999999
-	},
-	{
-		"title": "Cloudflare - Johannesburg",
-		"latitude": -26.2041028,
-		"longitude": 27.7973051
-	},
-	{
-		"title": "Cloudflare - Kansas City",
-		"latitude": 39.0997265,
-		"longitude": -94.5785667
-	},
-	{
-		"title": "Cloudflare - Kathmandu",
-		"latitude": 27.7172453,
-		"longitude": 85.3239605
-	},
-	{
-		"title": "Cloudflare - Kiev",
-		"latitude": 50.4501,
-		"longitude": 30.5234
-	},
-	{
-		"title": "Cloudflare - Kuala Lumpur",
-		"latitude": 3.139003,
-		"longitude": 101.686855
-	},
-	{
-		"title": "Cloudflare - Kuwait City",
-		"latitude": 29.375859,
-		"longitude": 47.9774052
-	},
-	{
-		"title": "Cloudflare - Las Vegas",
-		"latitude": 36.1699412,
-		"longitude": -115.1398296
-	},
-	{
-		"title": "Cloudflare - Lima",
-		"latitude": -12.0463731,
-		"longitude": -77.042754
-	},
-	{
-		"title": "Cloudflare - Lisbon",
-		"latitude": 38.7222524,
-		"longitude": -9.1393366
-	},
-	{
-		"title": "Cloudflare - London",
-		"latitude": 51.2573509,
-		"longitude": -0.6277583
-	},
-	{
-		"title": "Cloudflare - Los Angeles",
-		"latitude": 33.9272342,
-		"longitude": -118.7436849
-	},
-	{
-		"title": "Cloudflare - Luanda",
-		"latitude": -8.839987599999999,
-		"longitude": 13.2894368
-	},
-	{
-		"title": "Cloudflare - Luxembourg City",
-		"latitude": 49.61162100000001,
-		"longitude": 6.1319346
-	},
-	{
-		"title": "Cloudflare - Macau",
-		"latitude": 22.198745,
-		"longitude": 113.543873
-	},
-	{
-		"title": "Cloudflare - Madrid",
-		"latitude": 40.4167754,
-		"longitude": -3.9537902
-	},
-	{
-		"title": "Cloudflare - Manchester",
-		"latitude": 53.4807593,
-		"longitude": -2.2426305
-	},
-	{
-		"title": "Cloudflare - Manila",
-		"latitude": 14.5995124,
-		"longitude": 120.9842195
-	},
-	{
-		"title": "Cloudflare - Marseille",
-		"latitude": 43.296482,
-		"longitude": 5.36978
-	},
-	{
-		"title": "Cloudflare - Mcallen",
-		"latitude": 26.2034071,
-		"longitude": -98.23001239999999
-	},
-	{
-		"title": "Cloudflare - Medellín",
-		"latitude": 6.244203,
-		"longitude": -75.5812119
-	},
-	{
-		"title": "Cloudflare - Melbourne",
-		"latitude": -37.8136276,
-		"longitude": 144.7130576
-	},
-	{
-		"title": "Cloudflare - Memphis",
-		"latitude": 35.1495343,
-		"longitude": -90.0489801
-	},
-	{
-		"title": "Cloudflare - Mexico City",
-		"latitude": 19.4326077,
-		"longitude": -99.133208
-	},
-	{
-		"title": "Cloudflare - Miami",
-		"latitude": 25.7616798,
-		"longitude": -80.4417902
-	},
-	{
-		"title": "Cloudflare - Milan",
-		"latitude": 45.4642035,
-		"longitude": 9.189982
-	},
-	{
-		"title": "Cloudflare - Minneapolis",
-		"latitude": 44.977753,
-		"longitude": -93.5150108
-	},
-	{
-		"title": "Cloudflare - Mombasa",
-		"latitude": -4.0434771,
-		"longitude": 39.6682065
-	},
-	{
-		"title": "Cloudflare - Montgomery",
-		"latitude": 32.3668052,
-		"longitude": -86.2999689
-	},
-	{
-		"title": "Cloudflare - Montréal",
-		"latitude": 45.5016889,
-		"longitude": -73.817256
-	},
-	{
-		"title": "Cloudflare - Moscow",
-		"latitude": 55.755826,
-		"longitude": 37.6172999
-	},
-	{
-		"title": "Cloudflare - Mumbai",
-		"latitude": 19.0759837,
-		"longitude": 72.6276559
-	},
-	{
-		"title": "Cloudflare - Munich",
-		"latitude": 48.1351253,
-		"longitude": 11.5819805
-	},
-	{
-		"title": "Cloudflare - Muscat",
-		"latitude": 23.58589,
-		"longitude": 58.4059227
-	},
-	{
-		"title": "Cloudflare - Nashville",
-		"latitude": 36.1626638,
-		"longitude": -86.7816016
-	},
-	{
-		"title": "Cloudflare - New Delhi",
-		"latitude": 28.6139391,
-		"longitude": 77.2090212
+		"title": "Cloudflare - San Jose",
+		"latitude": 37.366737,
+		"longitude": -121.92638
 	},
 	{
 		"title": "Cloudflare - Newark",
-		"latitude": 40.735657,
-		"longitude": -74.4223667
+		"latitude": 40.68907,
+		"longitude": -74.17876
 	},
 	{
-		"title": "Cloudflare - Omaha",
-		"latitude": 41.2565369,
-		"longitude": -95.9345034
+		"title": "Cloudflare - Los Angeles",
+		"latitude": 33.943398,
+		"longitude": -118.40828
 	},
 	{
-		"title": "Cloudflare - Osaka",
-		"latitude": 34.6937378,
-		"longitude": 135.2521651
+		"title": "Cloudflare - Chicago",
+		"latitude": 41.976913,
+		"longitude": -87.90488
 	},
 	{
-		"title": "Cloudflare - Oslo",
-		"latitude": 59.9138688,
-		"longitude": 10.7522454
+		"title": "Cloudflare - Dallas",
+		"latitude": 32.89746,
+		"longitude": -97.036125
 	},
 	{
-		"title": "Cloudflare - Panama City",
-		"latitude": 30.1588129,
-		"longitude": -85.6602058
+		"title": "Cloudflare - Ashburn",
+		"latitude": 38.95315,
+		"longitude": -77.44774
+	},
+	{
+		"title": "Cloudflare - Miami",
+		"latitude": 25.796,
+		"longitude": -80.27824
 	},
 	{
 		"title": "Cloudflare - Paris",
-		"latitude": 48.731614,
-		"longitude": 2.1022219
+		"latitude": 49.003197,
+		"longitude": 2.567023
 	},
 	{
-		"title": "Cloudflare - Perth",
-		"latitude": -31.9505269,
-		"longitude": 115.6104572
+		"title": "Cloudflare - Amsterdam",
+		"latitude": 52.30907,
+		"longitude": 4.763385
 	},
 	{
-		"title": "Cloudflare - Philadelphia",
-		"latitude": 39.9525839,
-		"longitude": -75.1652215
-	},
-	{
-		"title": "Cloudflare - Phnom",
-		"latitude": 11.5563738,
-		"longitude": 104.9282099
-	},
-	{
-		"title": "Cloudflare - Phoenix",
-		"latitude": 33.4483771,
-		"longitude": -112.0740373
-	},
-	{
-		"title": "Cloudflare - Pittsburgh",
-		"latitude": 40.44062479999999,
-		"longitude": -79.9958864
-	},
-	{
-		"title": "Cloudflare - Port Louis",
-		"latitude": -20.1608912,
-		"longitude": 57.5012222
-	},
-	{
-		"title": "Cloudflare - Portland",
-		"latitude": 45.5122308,
-		"longitude": -122.6587185
-	},
-	{
-		"title": "Cloudflare - Prague",
-		"latitude": 50.0755381,
-		"longitude": 14.4378005
-	},
-	{
-		"title": "Cloudflare - Quito",
-		"latitude": -0.1806532,
-		"longitude": -78.4678382
-	},
-	{
-		"title": "Cloudflare - Reykjavík",
-		"latitude": 64.12652059999999,
-		"longitude": -21.8174392
-	},
-	{
-		"title": "Cloudflare - Riga",
-		"latitude": 56.9496487,
-		"longitude": 24.1051865
-	},
-	{
-		"title": "Cloudflare - Rio de Janeiro",
-		"latitude": -22.9068467,
-		"longitude": -43.4228965
-	},
-	{
-		"title": "Cloudflare - Riyadh",
-		"latitude": 24.7135517,
-		"longitude": 46.6752957
-	},
-	{
-		"title": "Cloudflare - Rome",
-		"latitude": 41.9027835,
-		"longitude": 12.4963655
-	},
-	{
-		"title": "Cloudflare - Sacramento",
-		"latitude": 38.5815719,
-		"longitude": -121.4943996
-	},
-	{
-		"title": "Cloudflare - Salt Lake City",
-		"latitude": 40.7607793,
-		"longitude": -111.8910474
-	},
-	{
-		"title": "Cloudflare - San Diego",
-		"latitude": 32.715738,
-		"longitude": -117.1610838
-	},
-	{
-		"title": "Cloudflare - San Jose",
-		"latitude": 37.2132082,
-		"longitude": -122.1363286
-	},
-	{
-		"title": "Cloudflare - São Paulo",
-		"latitude": -23.6755199,
-		"longitude": -46.88330939999999
-	},
-	{
-		"title": "Cloudflare - Saskatoon",
-		"latitude": 52.1332144,
-		"longitude": -106.6700458
-	},
-	{
-		"title": "Cloudflare - Seattle",
-		"latitude": 47.4812095,
-		"longitude": -122.5820708
-	},
-	{
-		"title": "Cloudflare - Seoul",
-		"latitude": 37.566535,
-		"longitude": 126.9779692
-	},
-	{
-		"title": "Cloudflare - Singapore",
-		"latitude": 1.227083,
-		"longitude": 103.569836
-	},
-	{
-		"title": "Cloudflare - Sofia",
-		"latitude": 42.6977082,
-		"longitude": 23.3218675
-	},
-	{
-		"title": "Cloudflare - St. Louis",
-		"latitude": 38.6270025,
-		"longitude": -90.19940419999999
-	},
-	{
-		"title": "Cloudflare - Stockholm",
-		"latitude": 59.32932349999999,
-		"longitude": 17.8185808
-	},
-	{
-		"title": "Cloudflare - Sydney",
-		"latitude": -33.9938197,
-		"longitude": 150.9592955
-	},
-	{
-		"title": "Cloudflare - Taipei",
-		"latitude": 25.0329694,
-		"longitude": 121.5654177
-	},
-	{
-		"title": "Cloudflare - Tallahassee",
-		"latitude": 30.4382559,
-		"longitude": -84.28073289999999
-	},
-	{
-		"title": "Cloudflare - Tallinn",
-		"latitude": 59.43696079999999,
-		"longitude": 24.7535747
-	},
-	{
-		"title": "Cloudflare - Tampa",
-		"latitude": 27.950575,
-		"longitude": -82.4571776
-	},
-	{
-		"title": "Cloudflare - Tel Aviv",
-		"latitude": 32.0852999,
-		"longitude": 34.53176759999999
+		"title": "Cloudflare - London",
+		"latitude": 51.469604,
+		"longitude": -0.453566
 	},
 	{
 		"title": "Cloudflare - Tokyo",
-		"latitude": 35.5644875,
-		"longitude": 139.1917064
+		"latitude": 35.773212,
+		"longitude": 140.38744
+	},
+	{
+		"title": "Cloudflare - Hong Kong",
+		"latitude": 22.315248,
+		"longitude": 113.93649
+	},
+	{
+		"title": "Cloudflare - Sydney",
+		"latitude": -33.932922,
+		"longitude": 151.1799
+	},
+	{
+		"title": "Cloudflare - Atlanta",
+		"latitude": 33.640068,
+		"longitude": -84.44403
+	},
+	{
+		"title": "Cloudflare - Seattle",
+		"latitude": 47.44384,
+		"longitude": -122.301735
 	},
 	{
 		"title": "Cloudflare - Toronto",
-		"latitude": 43.653226,
-		"longitude": -79.6331843
+		"latitude": 43.681583,
+		"longitude": -79.61146
 	},
 	{
-		"title": "Cloudflare - Valparaíso",
-		"latitude": -33.047238,
-		"longitude": -71.61268849999999
+		"title": "Cloudflare - Prague",
+		"latitude": 50.10619,
+		"longitude": 14.266638
+	},
+	{
+		"title": "Cloudflare - Seoul",
+		"latitude": 37.448524,
+		"longitude": 126.45123
+	},
+	{
+		"title": "Cloudflare - Singapore",
+		"latitude": 1.361173,
+		"longitude": 103.990204
+	},
+	{
+		"title": "Cloudflare - Valpara铆so",
+		"latitude": -33.397175,
+		"longitude": -70.79382
+	},
+	{
+		"title": "Cloudflare - Milan",
+		"latitude": 45.627403,
+		"longitude": 8.71237
+	},
+	{
+		"title": "Cloudflare - Madrid",
+		"latitude": 40.46515,
+		"longitude": -3.570209
+	},
+	{
+		"title": "Cloudflare - Medell铆n",
+		"latitude": 6.171382,
+		"longitude": -75.42821
+	},
+	{
+		"title": "Cloudflare - Lima",
+		"latitude": -12.019421,
+		"longitude": -77.107666
+	},
+	{
+		"title": "Cloudflare - Buenos Aires",
+		"latitude": -34.81273,
+		"longitude": -58.539833
+	},
+	{
+		"title": "Cloudflare - Johannesburg",
+		"latitude": -26.132664,
+		"longitude": 28.231314
+	},
+	{
+		"title": "Cloudflare - Auckland",
+		"latitude": -37.004787,
+		"longitude": 174.78352
+	},
+	{
+		"title": "Cloudflare - Melbourne",
+		"latitude": -37.669613,
+		"longitude": 144.84978
+	},
+	{
+		"title": "Cloudflare - D眉sseldorf",
+		"latitude": 51.278328,
+		"longitude": 6.76558
+	},
+	{
+		"title": "Cloudflare - Marseille",
+		"latitude": 43.44178,
+		"longitude": 5.222137
+	},
+	{
+		"title": "Cloudflare - Bucharest",
+		"latitude": 44.571156,
+		"longitude": 26.077063
+	},
+	{
+		"title": "Cloudflare - Osaka",
+		"latitude": 34.43533,
+		"longitude": 135.24397
+	},
+	{
+		"title": "Cloudflare - Dublin",
+		"latitude": 53.42728,
+		"longitude": -6.24357
+	},
+	{
+		"title": "Cloudflare - Kuwait City",
+		"latitude": 29.240116,
+		"longitude": 47.971252
+	},
+	{
+		"title": "Cloudflare - Doha",
+		"latitude": 25.267569,
+		"longitude": 51.558067
+	},
+	{
+		"title": "Cloudflare - Muscat",
+		"latitude": 23.588078,
+		"longitude": 58.29022
+	},
+	{
+		"title": "Cloudflare - Kuala Lumpur",
+		"latitude": 2.755672,
+		"longitude": 101.70539
+	},
+	{
+		"title": "Cloudflare - New Delhi",
+		"latitude": 28.556555,
+		"longitude": 77.10079
+	},
+	{
+		"title": "Cloudflare - Mumbai",
+		"latitude": 19.095509,
+		"longitude": 72.87497
+	},
+	{
+		"title": "Cloudflare - Chennai",
+		"latitude": 12.982267,
+		"longitude": 80.16378
+	},
+	{
+		"title": "Cloudflare - Dubai",
+		"latitude": 25.248665,
+		"longitude": 55.352917
+	},
+	{
+		"title": "Cloudflare - Mombasa",
+		"latitude": -4.0327,
+		"longitude": 39.60325
+	},
+	{
+		"title": "Cloudflare - Cairo",
+		"latitude": 30.120106,
+		"longitude": 31.40647
+	},
+	{
+		"title": "Cloudflare - Manchester",
+		"latitude": 53.362907,
+		"longitude": -2.273354
+	},
+	{
+		"title": "Cloudflare - Z眉rich",
+		"latitude": 47.450603,
+		"longitude": 8.561746
+	},
+	{
+		"title": "Cloudflare - Copenhagen",
+		"latitude": 55.62905,
+		"longitude": 12.647601
+	},
+	{
+		"title": "Cloudflare - Phoenix",
+		"latitude": 33.435036,
+		"longitude": -112.00016
+	},
+	{
+		"title": "Cloudflare - Berlin",
+		"latitude": 52.553944,
+		"longitude": 13.291722
+	},
+	{
+		"title": "Cloudflare - Manila",
+		"latitude": 14.5995,
+		"longitude": 120.9842
 	},
 	{
 		"title": "Cloudflare - Vancouver",
-		"latitude": 49.2827291,
-		"longitude": -123.3707375
+		"latitude": 49.1947,
+		"longitude": -123.17919
 	},
 	{
-		"title": "Cloudflare - Vienna",
-		"latitude": 48.2081743,
-		"longitude": 16.3738189
+		"title": "Cloudflare - Montr茅al",
+		"latitude": 45.457714,
+		"longitude": -73.74991
 	},
 	{
-		"title": "Cloudflare - Vilnius",
-		"latitude": 54.6871555,
-		"longitude": 25.2796514
+		"title": "Cloudflare - Frankfurt",
+		"latitude": 50.050735,
+		"longitude": 8.570773
+	},
+	{
+		"title": "Cloudflare - Minneapolis",
+		"latitude": 44.883015,
+		"longitude": -93.21092
 	},
 	{
 		"title": "Cloudflare - Warsaw",
-		"latitude": 52.2296756,
-		"longitude": 21.0122287
+		"latitude": 52.170906,
+		"longitude": 20.97329
+	},
+	{
+		"title": "Cloudflare - Sofia",
+		"latitude": 42.688343,
+		"longitude": 23.41443
+	},
+	{
+		"title": "Cloudflare - Hamburg",
+		"latitude": 53.63128,
+		"longitude": 10.006414
+	},
+	{
+		"title": "Cloudflare - Edinburgh",
+		"latitude": 55.9533,
+		"longitude": -3.1883
+	},
+	{
+		"title": "Cloudflare - Brussels",
+		"latitude": 50.89717,
+		"longitude": 4.483602
+	},
+	{
+		"title": "Cloudflare - Helsinki",
+		"latitude": 60.1699,
+		"longitude": 24.9384
+	},
+	{
+		"title": "Cloudflare - Taipei",
+		"latitude": 25.07639,
+		"longitude": 121.22389
+	},
+	{
+		"title": "Cloudflare - Las Vegas",
+		"latitude": 36.084,
+		"longitude": -115.1537
+	},
+	{
+		"title": "Cloudflare - Oslo",
+		"latitude": 60.19419,
+		"longitude": 11.100411
+	},
+	{
+		"title": "Cloudflare - Perth",
+		"latitude": -31.933603,
+		"longitude": 115.960236
+	},
+	{
+		"title": "Cloudflare - Brisbane",
+		"latitude": -27.3942,
+		"longitude": 153.1218
+	},
+	{
+		"title": "Cloudflare - Bangkok",
+		"latitude": 13.693062,
+		"longitude": 100.752045
+	},
+	{
+		"title": "Cloudflare - Moscow",
+		"latitude": 55.414566,
+		"longitude": 37.899494
+	},
+	{
+		"title": "Cloudflare - Athens",
+		"latitude": 37.9356,
+		"longitude": 23.9484
+	},
+	{
+		"title": "Cloudflare - Barcelona",
+		"latitude": 41.3851,
+		"longitude": 2.1734
+	},
+	{
+		"title": "Cloudflare - Panama City",
+		"latitude": 8.9824,
+		"longitude": -79.5199
+	},
+	{
+		"title": "Cloudflare - St. Louis",
+		"latitude": 38.627,
+		"longitude": -90.1994
+	},
+	{
+		"title": "Cloudflare - Quito",
+		"latitude": -0.1807,
+		"longitude": -78.4678
+	},
+	{
+		"title": "Cloudflare - Luanda",
+		"latitude": -8.84,
+		"longitude": 13.2894
+	},
+	{
+		"title": "Cloudflare - S茫o Paulo",
+		"latitude": -23.425669,
+		"longitude": -46.481926
+	},
+	{
+		"title": "Cloudflare - Denver",
+		"latitude": 39.8561,
+		"longitude": -104.6737
+	},
+	{
+		"title": "Cloudflare - Munich",
+		"latitude": 48.1351,
+		"longitude": 11.582
+	},
+	{
+		"title": "Cloudflare - Rio de Janeiro",
+		"latitude": -22.9068,
+		"longitude": -43.1729
+	},
+	{
+		"title": "Cloudflare - Philadelphia",
+		"latitude": 39.8744,
+		"longitude": -75.2424
+	},
+	{
+		"title": "Cloudflare - Tampa",
+		"latitude": 27.9835,
+		"longitude": -82.5371
 	},
 	{
 		"title": "Cloudflare - Willemstad",
-		"latitude": 12.1224221,
-		"longitude": -68.8824233
+		"latitude": 12.1224,
+		"longitude": -68.8824
 	},
 	{
-		"title": "Cloudflare - Winnipeg",
-		"latitude": 49.895136,
-		"longitude": -97.13837439999999
+		"title": "Cloudflare - Boston",
+		"latitude": 42.3656,
+		"longitude": -71.0096
+	},
+	{
+		"title": "Cloudflare - Lisbon",
+		"latitude": 38.7756,
+		"longitude": -9.1354
+	},
+	{
+		"title": "Cloudflare - San Diego",
+		"latitude": 32.7157,
+		"longitude": -117.1611
+	},
+	{
+		"title": "Cloudflare - Colombo",
+		"latitude": 6.9271,
+		"longitude": 79.8612
+	},
+	{
+		"title": "Cloudflare - Cape Town",
+		"latitude": -33.9249,
+		"longitude": 18.4241
+	},
+	{
+		"title": "Cloudflare - Vienna",
+		"latitude": 48.11972,
+		"longitude": 16.563583
+	},
+	{
+		"title": "Cloudflare - Nashville",
+		"latitude": 36.1263,
+		"longitude": -86.6774
+	},
+	{
+		"title": "Cloudflare - Detroit",
+		"latitude": 42.3314,
+		"longitude": -83.0458
 	},
 	{
 		"title": "Cloudflare - Yerevan",
-		"latitude": 40.1791857,
-		"longitude": 44.4991029
+		"latitude": 40.1792,
+		"longitude": 44.4991
+	},
+	{
+		"title": "Cloudflare - Istanbul",
+		"latitude": 41.0082,
+		"longitude": 28.9784
+	},
+	{
+		"title": "Cloudflare - Portland",
+		"latitude": 45.512794,
+		"longitude": -122.679565
+	},
+	{
+		"title": "Cloudflare - Belgrade",
+		"latitude": 44.7866,
+		"longitude": 20.4489
+	},
+	{
+		"title": "Cloudflare - Omaha",
+		"latitude": 41.2997,
+		"longitude": -95.8995
+	},
+	{
+		"title": "Cloudflare - Djibouti",
+		"latitude": 11.8251,
+		"longitude": 42.5903
+	},
+	{
+		"title": "Cloudflare - Budapest",
+		"latitude": 47.4979,
+		"longitude": 19.0402
 	},
 	{
 		"title": "Cloudflare - Zagreb",
-		"latitude": 45.8150108,
-		"longitude": 15.9819189
+		"latitude": 45.815,
+		"longitude": 15.9819
 	},
 	{
-		"title": "Cloudflare - Zürich",
-		"latitude": 47.3768866,
-		"longitude": 8.541694
+		"title": "Cloudflare - Kansas City",
+		"latitude": 39.0997,
+		"longitude": -94.5786
+	},
+	{
+		"title": "Cloudflare - Rome",
+		"latitude": 41.9028,
+		"longitude": 12.4964
+	},
+	{
+		"title": "Cloudflare - Stockholm",
+		"latitude": 59.64982,
+		"longitude": 17.930365
+	},
+	{
+		"title": "Cloudflare - Riyadh",
+		"latitude": 24.7136,
+		"longitude": 46.6753
+	},
+	{
+		"title": "Cloudflare - Kyiv",
+		"latitude": 50.341244,
+		"longitude": 30.895206
+	},
+	{
+		"title": "Cloudflare - Mcallen",
+		"latitude": 26.1758003,
+		"longitude": -98.2386017
+	},
+	{
+		"title": "Cloudflare - Durban",
+		"latitude": -29.8587,
+		"longitude": 31.0218
+	},
+	{
+		"title": "Cloudflare - Pittsburgh",
+		"latitude": 40.4406,
+		"longitude": -79.9959
+	},
+	{
+		"title": "Cloudflare - Sacramento",
+		"latitude": 38.5816,
+		"longitude": -121.4944
+	},
+	{
+		"title": "Cloudflare - Port Louis",
+		"latitude": -20.1609,
+		"longitude": 57.5012
+	},
+	{
+		"title": "Cloudflare - Macau",
+		"latitude": 22.1987,
+		"longitude": 113.5439
+	},
+	{
+		"title": "Cloudflare - Cebu City",
+		"latitude": 10.3157,
+		"longitude": 123.8854
+	},
+	{
+		"title": "Cloudflare - Kathmandu",
+		"latitude": 27.7172,
+		"longitude": 85.324
+	},
+	{
+		"title": "Cloudflare - Salt Lake City",
+		"latitude": 40.7608,
+		"longitude": -111.891
+	},
+	{
+		"title": "Cloudflare - Phnom Penh",
+		"latitude": 11.5449,
+		"longitude": 104.8922
+	},
+	{
+		"title": "Cloudflare - Reykjav铆k",
+		"latitude": 64.1265,
+		"longitude": -21.8174
+	},
+	{
+		"title": "Cloudflare - Baghdad",
+		"latitude": 33.3128,
+		"longitude": 44.3615
+	},
+	{
+		"title": "Cloudflare - Vilnius",
+		"latitude": 54.6872,
+		"longitude": 25.2797
+	},
+	{
+		"title": "Cloudflare - Tel Aviv",
+		"latitude": 32.0853,
+		"longitude": 34.7818
+	},
+	{
+		"title": "Cloudflare - Beirut",
+		"latitude": 33.8938,
+		"longitude": 35.5018
+	},
+	{
+		"title": "Cloudflare - Riga",
+		"latitude": 56.9496,
+		"longitude": 24.1052
+	},
+	{
+		"title": "Cloudflare - Tallinn",
+		"latitude": 59.437,
+		"longitude": 24.7536
+	},
+	{
+		"title": "Cloudflare - Calgary",
+		"latitude": 51.0486,
+		"longitude": -114.0708
+	},
+	{
+		"title": "Cloudflare - Indianapolis",
+		"latitude": 39.7684,
+		"longitude": -86.1581
+	},
+	{
+		"title": "Cloudflare - Jacksonville",
+		"latitude": 30.3322,
+		"longitude": -81.6557
+	},
+	{
+		"title": "Cloudflare - Memphis",
+		"latitude": 35.1495,
+		"longitude": -90.049
+	},
+	{
+		"title": "Cloudflare - Montgomery",
+		"latitude": 32.3668,
+		"longitude": -86.3
+	},
+	{
+		"title": "Cloudflare - Mexico City",
+		"latitude": 19.4326,
+		"longitude": -99.1332
+	},
+	{
+		"title": "Cloudflare - Tallahassee",
+		"latitude": 30.4383,
+		"longitude": -84.2807
+	},
+	{
+		"title": "Cloudflare - Bogota",
+		"latitude": 4.711,
+		"longitude": -74.0721
+	},
+	{
+		"title": "Cloudflare - Houston",
+		"latitude": 29.7604,
+		"longitude": -95.3698
+	},
+	{
+		"title": "Cloudflare - Chi葯in膬u",
+		"latitude": 47.0105,
+		"longitude": 28.8638
+	},
+	{
+		"title": "Cloudflare - Saskatoon",
+		"latitude": 52.1332,
+		"longitude": -106.67
+	},
+	{
+		"title": "Cloudflare - Winnipeg",
+		"latitude": 49.8951,
+		"longitude": -97.1384
+	},
+	{
+		"title": "Cloudflare - Luxembourg City",
+		"latitude": 49.6116,
+		"longitude": 6.1319
+	},
+	{
+		"title": "Cloudflare - Norfolk",
+		"latitude": 36.8508,
+		"longitude": -76.2859
+	},
+	{
+		"title": "Cloudflare - Richmond",
+		"latitude": 37.5407,
+		"longitude": -77.436
+	},
+	{
+		"title": "Cloudflare - Ulaanbaatar",
+		"latitude": 47.8864,
+		"longitude": 106.9057
+	},
+	{
+		"title": "Cloudflare - Lagos",
+		"latitude": 6.5772,
+		"longitude": 3.3189
+	},
+	{
+		"title": "Cloudflare - Charlotte",
+		"latitude": 35.2271,
+		"longitude": -80.8431
+	},
+	{
+		"title": "Cloudflare - Columbus",
+		"latitude": 39.9612,
+		"longitude": -82.9988
+	},
+	{
+		"title": "Cloudflare - Manama",
+		"latitude": 26.2285,
+		"longitude": 50.586
+	},
+	{
+		"title": "Cloudflare - St. Petersburg",
+		"latitude": 59.9343,
+		"longitude": 30.3351
+	},
+	{
+		"title": "Cloudflare - Hanoi",
+		"latitude": 21.0278,
+		"longitude": 105.8342
+	},
+	{
+		"title": "Cloudflare - Ho Chi Minh City",
+		"latitude": 10.8231,
+		"longitude": 106.6297
+	},
+	{
+		"title": "Cloudflare - Islamabad",
+		"latitude": 33.6844,
+		"longitude": 73.0479
+	},
+	{
+		"title": "Cloudflare - Karachi",
+		"latitude": 24.8607,
+		"longitude": 67.0011
+	},
+	{
+		"title": "Cloudflare - Lahore",
+		"latitude": 31.5204,
+		"longitude": 74.3587
+	},
+	{
+		"title": "Cloudflare - Reunion",
+		"latitude": -21.1151,
+		"longitude": 55.5364
+	},
+	{
+		"title": "Cloudflare - Fortaleza",
+		"latitude": -3.71722,
+		"longitude": -38.54306
+	},
+	{
+		"title": "Cloudflare - Curitiba",
+		"latitude": -25.42778,
+		"longitude": -49.27306
+	},
+	{
+		"title": "Cloudflare - Porto Alegre",
+		"latitude": -30.03306,
+		"longitude": -51.23
+	},
+	{
+		"title": "Cloudflare - Ottawa",
+		"latitude": 45.41117,
+		"longitude": -75.69812
+	},
+	{
+		"title": "Cloudflare - Queretaro",
+		"latitude": 20.58806,
+		"longitude": -100.38806
+	},
+	{
+		"title": "Cloudflare - Amman",
+		"latitude": 31.95522,
+		"longitude": 35.94503
+	},
+	{
+		"title": "Cloudflare - Ramallah",
+		"latitude": 31.89964,
+		"longitude": 35.20422
+	},
+	{
+		"title": "Cloudflare - Casablanca",
+		"latitude": 33.58831,
+		"longitude": -7.61138
+	},
+	{
+		"title": "Cloudflare - Hyderabad",
+		"latitude": 17.38405,
+		"longitude": 78.45636
+	},
+	{
+		"title": "Cloudflare - Geneva",
+		"latitude": 46.20222,
+		"longitude": 6.14569
+	},
+	{
+		"title": "Cloudflare - Baku",
+		"latitude": 40.4093,
+		"longitude": 49.8671
+	},
+	{
+		"title": "Cloudflare - Buffalo",
+		"latitude": 42.8864,
+		"longitude": -78.8784
+	},
+	{
+		"title": "Cloudflare - Goteburg",
+		"latitude": 57.7089,
+		"longitude": 11.9746
+	},
+	{
+		"title": "Cloudflare - Nicosia",
+		"latitude": 35.1856,
+		"longitude": 33.3823
+	},
+	{
+		"title": "Cloudflare - Thessaloniki",
+		"latitude": 40.6401,
+		"longitude": 22.9444
+	},
+	{
+		"title": "Cloudflare - Maputo",
+		"latitude": -25.9692,
+		"longitude": 32.5732
+	},
+	{
+		"title": "Cloudflare - Kigali",
+		"latitude": -1.9706,
+		"longitude": 30.1044
+	},
+	{
+		"title": "Cloudflare - Asuncion",
+		"latitude": -25.2637,
+		"longitude": -57.5759
+	},
+	{
+		"title": "Cloudflare - Dar Es Salaam",
+		"latitude": -6.7924,
+		"longitude": 39.2083
+	},
+	{
+		"title": "Cloudflare - Port-Au-Prince",
+		"latitude": 18.5944,
+		"longitude": -72.3074
+	},
+	{
+		"title": "Cloudflare - Noumea",
+		"latitude": -22.2711,
+		"longitude": 166.4416
+	},
+	{
+		"title": "Cloudflare - Guatemala City",
+		"latitude": 14.6349,
+		"longitude": -90.5069
+	},
+	{
+		"title": "Cloudflare - Bengaluru",
+		"latitude": 12.9716,
+		"longitude": 77.5946
+	},
+	{
+		"title": "Cloudflare - Nagpur",
+		"latitude": 21.1458,
+		"longitude": 79.0882
+	},
+	{
+		"title": "Cloudflare - Cork",
+		"latitude": 51.8985,
+		"longitude": -8.4756
+	},
+	{
+		"title": "Cloudflare - Kolkata",
+		"latitude": 22.5726,
+		"longitude": 88.3639
+	},
+	{
+		"title": "Cloudflare - Male",
+		"latitude": 4.1755,
+		"longitude": 73.5093
+	},
+	{
+		"title": "Cloudflare - Jakarta",
+		"latitude": -6.2088,
+		"longitude": 106.8456
+	},
+	{
+		"title": "Cloudflare - Neuquen",
+		"latitude": -38.9517,
+		"longitude": -68.0592
+	},
+	{
+		"title": "Cloudflare - Arica",
+		"latitude": -18.4783,
+		"longitude": -70.3126
+	},
+	{
+		"title": "Cloudflare - Cordoba",
+		"latitude": -31.4201,
+		"longitude": -64.1888
+	},
+	{
+		"title": "Cloudflare - Dakar",
+		"latitude": 14.7167,
+		"longitude": -17.4677
+	},
+	{
+		"title": "Cloudflare - Antananarivo",
+		"latitude": -18.8792,
+		"longitude": 47.5079
 	},
 	{
 		"title": "Fastly - Amsterdam",


### PR DESCRIPTION
The data of Cloudflare data center can be found at: https://www.cloudflare.com/data/current-pops.csv , which is used to render [Cloudflare Network Map](https://www.cloudflare.com/network/). I have removed `CN` PoPs from the data, turned it into formatted json, and bring up this PR.

