### PR TITLE
Legacy url.parse is deprecated; switching to new URL constructor

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -337,7 +337,7 @@ server.use('/blog', (req, res, next) => {
 /**
  * Proxy blog requests to ghost.
  */
-server.use('/blog', proxy(serverConfig.blogHost, app.env === 'development' ? `localhost:${serverConfig.port}` : serverConfig.host));
+server.use('/blog', proxy(serverConfig.blogHost, app.env === 'development' ? `http://localhost:${serverConfig.port}` : serverConfig.host));
 
 /**
  * Forward everything else to Koa (main website).

--- a/src/proxy.js
+++ b/src/proxy.js
@@ -17,6 +17,11 @@ module.exports = (proxyTarget, host) => {
 	let rewriteElements = [ 'loc' ];
 
 	let rewrite = (link, baseUrl) => {
+		// A relative URL without a leading slash. No transformation needed.
+		if (!link.includes('://') && !link.startsWith('/')) {
+			return link;
+		}
+
 		let parsed = new URL(link, proxyTarget + baseUrl);
 
 		if (matchesHost(parsed, proxyUrl.host)) {

--- a/src/proxy.js
+++ b/src/proxy.js
@@ -11,13 +11,13 @@ const cssUrlPattern = /url\(\s*(['"])((?:\\[\s\S]|(?!\1).)*)\1\s*\)|url\(((?:\\[
 
 module.exports = (proxyTarget, host) => {
 	let proxy = httpProxy.createProxyServer();
-	let proxyUrl = url.parse(proxyTarget, false, true);
-	let hostUrl = url.parse(host, false, true);
+	let proxyUrl = new URL(proxyTarget);
+	let hostUrl = new URL(host);
 	let rewriteAttributes = [ 'action', 'href', 'link', 'src', 'srcset', 'style' ];
 	let rewriteElements = [ 'loc' ];
 
 	let rewrite = (link, baseUrl) => {
-		let parsed = url.parse(link, false, true);
+		let parsed = new URL(link);
 
 		if (matchesHost(parsed, proxyUrl.host)) {
 			if (parsed.host) {

--- a/src/proxy.js
+++ b/src/proxy.js
@@ -17,7 +17,7 @@ module.exports = (proxyTarget, host) => {
 	let rewriteElements = [ 'loc' ];
 
 	let rewrite = (link, baseUrl) => {
-		let parsed = new URL(link);
+		let parsed = new URL(link, proxyTarget + baseUrl);
 
 		if (matchesHost(parsed, proxyUrl.host)) {
 			if (parsed.host) {


### PR DESCRIPTION
Respective documentations: https://nodejs.org/api/url.html#url_constructor_new_url_input_base
