### PR TITLE
Enforce LF.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-# Auto detect text files and perform LF normalization
-* text=auto
+# Enforce Unix newlines
+* text=auto eol=lf


### PR DESCRIPTION
The previous solution didn't enforce LF. On Windows, CRLF was used which caused linting to fail.

Requires git >= 2.10.