### PR TITLE
Remove fs-extra

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,8 @@ global.apmClient.addTransactionFilter(require('elastic-apm-utils').apm.transacti
 require('./lib/startup');
 
 const _ = require('lodash');
-const fs = require('fs-extra');
+const fs = require('fs');
+const { promisify } = require('util');
 const config = require('config');
 const signalExit = require('signal-exit');
 const isSafePath = require('is-safe-path');
@@ -53,6 +54,8 @@ let siteMapIndexTemplate = Handlebars.compile(fs.readFileSync(__dirname + '/view
 
 let app = new Koa();
 let router = new KoaRouter();
+
+const readFileAsync = promisify(fs.readFile);
 
 /**
  * Server config.
@@ -213,7 +216,7 @@ koaElasticUtils.addRoutes(router, [
 	[ '/sitemap/:page', '/sitemap/:page' ],
 ], async (ctx) => {
 	ctx.params.page = ctx.params.page.replace(/\.xml$/, '');
-	let packages = JSON.parse(await fs.readFile(pathToPackages, 'utf8'));
+	let packages = JSON.parse(await readFileAsync(pathToPackages, 'utf8'));
 	let pages = (await readDirRecursive(__dirname + '/views/pages', [ '_*' ])).map(p => path.relative(__dirname + '/views/pages', p).replace(/\\/g, '/').slice(0, -5));
 	let maxPage = Math.ceil(packages.length / 50000);
 	let page = Number(ctx.params.page);

--- a/src/middleware/less/index.js
+++ b/src/middleware/less/index.js
@@ -1,7 +1,10 @@
-const less = require('less');
+const fs = require('fs');
 const path = require('path');
-const fs = require('fs-extra');
+const { promisify } = require('util');
+const less = require('less');
 const CleanCSS = require('clean-css');
+
+const readFileAsync = promisify(fs.readFile);
 const cssCache = new Map();
 
 module.exports = (prefix, options) => {
@@ -36,7 +39,11 @@ module.exports = (prefix, options) => {
 };
 
 async function compileLess (file, minify) {
-	return less.render(await fs.readFileAsync(file, 'utf8'), { filename: file, strictMath: true, relativeUrls: true }).then((output) => {
+	return less.render(await readFileAsync(file, 'utf8'), {
+		filename: file,
+		strictMath: true,
+		relativeUrls: true,
+	}).then((output) => {
 		return minify ? minifyCss(output.css) : output.css;
 	});
 }

--- a/src/middleware/render/index.js
+++ b/src/middleware/render/index.js
@@ -1,8 +1,10 @@
-const Ractive = require('ractive');
+const fs = require('fs');
 const path = require('path');
-const fs = require('fs-extra');
+const { promisify } = require('util');
+const Ractive = require('ractive');
 const rcu = require('rcu');
 
+const readFileAsync = promisify(fs.readFile);
 const componentCache = new Map();
 
 rcu.init(Ractive);
@@ -49,7 +51,7 @@ async function getComponent (href, options) {
 
 async function makeComponent (href, options) {
 	let viewsHref = path.join(options.views, href);
-	let template = await fs.readFileAsync(viewsHref, 'utf8');
+	let template = await readFileAsync(viewsHref, 'utf8');
 
 	return new Promise((resolve, reject) => {
 		try {


### PR DESCRIPTION
There are still 2 instances, one in lib/startup.js and one in test/tests.js.

Feel free to push to my branch :)

BTW keep in mind that there's a `fs.promises` API starting from Node.js 10: https://nodejs.org/docs/latest-v12.x/api/fs.html#fs_fs_promises_api

Refs #353 