### PR TITLE
Updated QUANTIL and Fastly Edge Locations

### DIFF
--- a/data/map.txt
+++ b/data/map.txt
@@ -188,28 +188,39 @@ Fastly - Cape Town
 Fastly - Chennai
 Fastly - Chicago
 Fastly - Chicago
+Fastly - Copenhagen
 Fastly - Columbus
+Fastly - Curitiba
+Fastly - Dallas
 Fastly - Dallas
 Fastly - Denver
 Fastly - Dubai
+Fastly - Dublin
 Fastly - Frankfurt
 Fastly - Frankfurt
+Fastly - Helsinki
 Fastly - Hong Kong
 Fastly - Houston
+Fastly - Jacksonville
 Fastly - Johannesburg
+Fastly - Kansas City
 Fastly - London
 Fastly - London
 Fastly - Los Angeles
 Fastly - Los Angeles
 Fastly - Madrid
+Fastly - Manchester
 Fastly - Melbourne
 Fastly - Miami
+Fastly - Milan
 Fastly - Minneapolis
 Fastly - Montreal
 Fastly - Mumbai
+Fastly - New Delhi
 Fastly - New York
 Fastly - New York
 Fastly - Newark
+Fastly - Oslo
 Fastly - Osaka
 Fastly - Paris
 Fastly - Perth
@@ -221,11 +232,13 @@ Fastly - São Paulo
 Fastly - Seattle
 Fastly - Singapore
 Fastly - Stockholm
+Fastly - St Louis
 Fastly - Sydney
 Fastly - Tokyo
 Fastly - Tokyo
 Fastly - Toronto
 Fastly - Vancouver
+Fastly - Vienna
 Fastly - Wellington
 StackPath - Amsterdam
 StackPath - Ashburn
@@ -262,23 +275,66 @@ StackPath - Toronto
 StackPath - Virginia
 StackPath - Warsaw
 Telma - Antananarivo
+QUANTIL - Amsterdam
+QUANTIL - Antananarivo
 QUANTIL - Anyang
+QUANTIL - Atlanta
+QUANTIL - Baghdad
+QUANTIL - Bandar Seri Begawan
 QUANTIL - Bangkok
+QUANTIL - Cape Town
 QUANTIL - Chengdu
+QUANTIL - Chicago
 QUANTIL - Chongqing
+QUANTIL - Dallas
+QUANTIL - Denver
 QUANTIL - Deyang
+QUANTIL - Djibouti
+QUANTIL - Dubai
+QUANTIL - Doha
+QUANTIL - Frankfurt
 QUANTIL - Ganzhou
 QUANTIL - Guiyang
+QUANTIL - Ho Chi Minh
+QUANTIL - Hong Kong
+QUANTIL - Jakarta
 QUANTIL - Jiaozuo
 QUANTIL - Jiaxing
 QUANTIL - Jilin
+QUANTIL - Johannesburg
+QUANTIL - Kuala Lumpur
 QUANTIL - Kunming
+QUANTIL - Kuwait City
+QUANTIL - Los Angeles
+QUANTIL - London
 QUANTIL - Lishui
+QUANTIL - Macao
+QUANTIL - Madrid
+QUANTIL - Melbourne
+QUANTIL - Miami
+QUANTIL - Milan
 QUANTIL - Mudanjiang
+QUANTIL - Manila
 QUANTIL - Nanchong
+QUANTIL - New York City
+QUANTIL - Paris
+QUANTIL - Phnom Penh
+QUANTIL - Port Louis
+QUANTIL - San Jose
+QUANTIL - Seattle
+QUANTIL - Seoul
 QUANTIL - Shanghai
 QUANTIL - Shenzhen
+QUANTIL - Singapore
+QUANTIL - St Petersburg
 QUANTIL - Suizhou
+QUANTIL - Suva
+QUANTIL - Sydney
+QUANTIL - Taipei
+QUANTIL - Tokyo
+QUANTIL - Ulan Bator
+QUANTIL - Vientiane
+QUANTIL - Washington DC
 QUANTIL - Weinan
 QUANTIL - Xi'an
 QUANTIL - Xinyang


### PR DESCRIPTION
updated QUANTIL and Fastly Edge Locations based upon the information given on the official website on the URL given here - https://www.quantil.com/content-delivery-network/ and https://www.fastly.com/network-map