### PR TITLE
nofollow for external sites

### DIFF
--- a/src/views/components/package-header.html
+++ b/src/views/components/package-header.html
@@ -51,7 +51,7 @@
 			{{#if license}}<span class="package-label" title="{{license}}"><i class="fa fa-balance-scale" aria-hidden="true"></i> {{license}}</span>{{/if}}
 			{{#if ~/vulnerabilities !== undefined}}
 			<span class="package-label" title="view details at snyk.io">
-				<a href="{{~/vulnerabilitiesUrl}}" target="_blank">
+				<a rel="nofollow noopener" href="{{~/vulnerabilitiesUrl}}" target="_blank">
 					<i class="fa {{#if ~/vulnerabilities}}fa-exclamation-circle{{else}}fa-check-circle{{/if}}" aria-hidden="true"></i>
 					{{~/vulnerabilities}} {{#if ~/vulnerabilities === 1}}vulnerability{{else}}vulnerabilities{{/if}}
 				</a>

--- a/src/views/components/package-header.html
+++ b/src/views/components/package-header.html
@@ -12,11 +12,11 @@
 		<div class="col-sm-4">
 			<div class="package-buttons">
 				{{#if !~/type || ~/type === 'npm'}}
-				<a target="_blank" rel="noopener" href="https://openbase.com/js/{{name}}" class="button" title="{{name}} docs & info">
+				<a target="_blank" rel="nofollow noopener" href="https://openbase.com/js/{{name}}" class="button" title="{{name}} docs & info">
 					<img width="20" height="20" src="/img/icons/openbase.svg" alt="{{name}} JS library on Openbase" title="{{name}} docs & info">
 				</a>
 				{{#if homepage}}
-				<a target="_blank" rel="noopener" href="{{homepage}}" class="button" title="Homepage">
+				<a target="_blank" rel="nofollow noopener" href="{{homepage}}" class="button" title="Homepage">
 					<i class="fa fa-globe" aria-hidden="true"></i>
 				</a>
 				{{/if}}


### PR DESCRIPTION
Not sure why we didnt have that for npm package sites, but now Google also punishes outgoing sites if it thinks its spam. So its best to make sure tag we dont get tagged as that.