### PR TITLE
Zoom in on the results

### DIFF
--- a/src/views/pages/globalping.html
+++ b/src/views/pages/globalping.html
@@ -2013,7 +2013,7 @@
 				}
 
 				// limit max zoom temp to avoid unnecessary zooming
-				map.setOptions({ maxZoom: 4 });
+				map.setOptions({ maxZoom: 6 });
 
 				let bounds = new google.maps.LatLngBounds();
 
@@ -2028,7 +2028,7 @@
 				});
 
 				map.fitBounds(bounds);
-			}, 500);
+			}, 100);
 		},
 	};
 </script>

--- a/src/views/pages/globalping.html
+++ b/src/views/pages/globalping.html
@@ -2004,7 +2004,7 @@
 		},
 		zoomToResults (locations) {
 			setTimeout(() => {
-				// do not zoom if test was done for the World
+				// do not zoom if test was done for the World.
 				if (
 					locations.length === 1
 					&& (locations[0].magic.toLowerCase() === 'world' || locations[0].magic === '')

--- a/src/views/pages/globalping.html
+++ b/src/views/pages/globalping.html
@@ -1259,6 +1259,7 @@
 						clearInterval(this.get('testReqInterval'));
 						this.set('testInProgress', false);
 						this.set('testResultsId', realTimeTestResResponse.id);
+						this.zoomToResults(realTimeTestResResponse.locations);
 					}
 
 					let prevTestResults = this.get('testResults') || [];
@@ -2000,6 +2001,34 @@
 
 				return res;
 			}, {});
+		},
+		zoomToResults (locations) {
+			setTimeout(() => {
+				// do not zoom if test was done for the World
+				if (
+					locations.length === 1
+					&& (locations[0].magic.toLowerCase() === 'world' || locations[0].magic === '')
+				) {
+					return;
+				}
+
+				// limit max zoom temp to avoid unnecessary zooming
+				map.setOptions({ maxZoom: 4 });
+
+				let bounds = new google.maps.LatLngBounds();
+
+				mapMarkers.forEach((mm) => {
+					bounds.extend(mm.getPosition());
+				});
+
+				google.maps.event.addListenerOnce(map, 'bounds_changed', () => {
+					map.panTo(bounds.getCenter());
+					// restore default zoom
+					map.setOptions({ maxZoom: 22 });
+				});
+
+				map.fitBounds(bounds);
+			}, 500);
 		},
 	};
 </script>


### PR DESCRIPTION
Fixes #538

 After test runs clear the probes map and start showing the results as they come in. At the end zoom in to fit all the results, but not too much. e.g. if users asks to ping from Poland then we should zoom in to Poland, but not to fill 100% of the map.

After the test is finished zoom in to fit all results. But not too much, something like a country level max (Same logic, zoom in to fit all dots on the map. Country is the max zoom in, but you must zoom out as much as needed)