### PR TITLE
Handle paste URL for HTTP test

### DIFF
--- a/src/assets/js/_.js
+++ b/src/assets/js/_.js
@@ -1244,9 +1244,9 @@ module.exports = {
 				resTiming = lastHop.stats.avg;
 			}
 		} else if (lowCaseTestName === 'http') {
-			resTiming = testResData.result.timings.total;
+			resTiming = testResData.result?.timings?.total;
 
-			if (typeof testResData.result.timings.dns === 'number') {
+			if (typeof testResData.result?.timings?.dns === 'number') {
 				extraValues.dns = {
 					text: 'DNS',
 					value: testResData.result.timings.dns,
@@ -1254,7 +1254,7 @@ module.exports = {
 				};
 			}
 
-			if (typeof testResData.result.timings.tcp === 'number') {
+			if (typeof testResData.result?.timings?.tcp === 'number') {
 				extraValues.tcp = {
 					text: 'TCP',
 					value: testResData.result.timings.tcp,
@@ -1262,7 +1262,7 @@ module.exports = {
 				};
 			}
 
-			if (typeof testResData.result.timings.tls === 'number') {
+			if (typeof testResData.result?.timings?.tls === 'number') {
 				extraValues.tls = {
 					text: 'TLS',
 					value: testResData.result.timings.tls,
@@ -1270,7 +1270,7 @@ module.exports = {
 				};
 			}
 
-			if (typeof testResData.result.timings.firstByte === 'number') {
+			if (typeof testResData.result?.timings?.firstByte === 'number') {
 				extraValues.firstByte = {
 					text: 'TTFB',
 					value: testResData.result.timings.firstByte,
@@ -1278,7 +1278,7 @@ module.exports = {
 				};
 			}
 
-			if (typeof testResData.result.timings.download === 'number') {
+			if (typeof testResData.result?.timings?.download === 'number') {
 				extraValues.download = {
 					text: 'Download',
 					value: testResData.result.timings.download,

--- a/src/views/pages/globalping.html
+++ b/src/views/pages/globalping.html
@@ -2046,10 +2046,11 @@
 			let rawPasteContent = (event.clipboardData || window.clipboardData).getData('text');
 
 			try {
-				let { protocol, pathname, hostname, search } = new URL(rawPasteContent);
+				let { protocol, port, pathname, hostname, search } = new URL(rawPasteContent);
 
 				this.set('mainOptions.target', hostname);
 				this.set('httpOpts.protocol', protocol.replace(':', '').toUpperCase());
+				this.set('notAppliedOpts.port', port);
 				this.set('notAppliedOpts.request.path', pathname);
 				this.set('notAppliedOpts.request.query', search.replace('?', ''));
 			} catch (err) {
@@ -2059,6 +2060,7 @@
 				this.set('httpOpts.protocol', defaultClientProtocol);
 				this.set('notAppliedOpts.request.path', '');
 				this.set('notAppliedOpts.request.query', '');
+				this.set('notAppliedOpts.port', '');
 			} finally {
 				this.applyOptions();
 			}

--- a/src/views/pages/globalping.html
+++ b/src/views/pages/globalping.html
@@ -326,7 +326,7 @@
 								{{#if mainOptions.type === 'HTTP'}}
 									<div class="typeHTTP">
 										<c-controlled-input
-											value="{{notAppliedOpts.host}}"
+											value="{{notAppliedOpts.request.host}}"
 											error="{{inputErrors.host}}"
 											placeholder="Host"
 											labelText="Host"
@@ -1170,6 +1170,7 @@
 				// if so - should be a share-results logic implemented
 				let qsStringsArr = this.get('@shared.app.router.uri.qs').replace('?', '').split('&');
 				let { measurement: measurementId } = Object.fromEntries(qsStringsArr.map(s => s.split('=')));
+				let boundHandleTargetInputPaste = this.handleTargetInputPaste.bind(this);
 
 				if (measurementId) {
 					this.set('measurementId', measurementId);
@@ -1206,6 +1207,16 @@
 					this.set('notAppliedOpts', {});
 					this.set('testFailed', false);
 					this.set('modifiedMeasOptsCnt', 0);
+
+
+					// handle focus out of Target input while HTTP test
+					let targetInput = this.find('#targetInput');
+
+					if (type.toLowerCase() === 'http') {
+						targetInput.addEventListener('paste', boundHandleTargetInputPaste);
+					} else {
+						targetInput.removeEventListener('paste', boundHandleTargetInputPaste);
+					}
 				}, { init: false });
 
 				// handle join-network switch and commands content
@@ -2029,6 +2040,30 @@
 
 				map.fitBounds(bounds);
 			}, 100);
+		},
+		handleTargetInputPaste (event) {
+			event.preventDefault();
+			let rawPasteContent = (event.clipboardData || window.clipboardData).getData('text');
+
+			try {
+				let { protocol, pathname, hostname, search } = new URL(rawPasteContent);
+
+				this.set('mainOptions.target', hostname);
+				this.set('httpOpts.protocol', protocol.replace(':', '').toUpperCase());
+				this.set('notAppliedOpts.request.host', hostname);
+				this.set('notAppliedOpts.request.path', pathname);
+				this.set('notAppliedOpts.request.query', search.replace('?', ''));
+			} catch (err) {
+				let { protocol: defaultClientProtocol } = this.getDefaultClientMeasOptsByTestName('http');
+
+				this.set('mainOptions.target', rawPasteContent);
+				this.set('httpOpts.protocol', defaultClientProtocol);
+				this.set('notAppliedOpts.request.host', '');
+				this.set('notAppliedOpts.request.path', '');
+				this.set('notAppliedOpts.request.query', '');
+			} finally {
+				this.applyOptions();
+			}
 		},
 	};
 </script>

--- a/src/views/pages/globalping.html
+++ b/src/views/pages/globalping.html
@@ -2050,7 +2050,6 @@
 
 				this.set('mainOptions.target', hostname);
 				this.set('httpOpts.protocol', protocol.replace(':', '').toUpperCase());
-				this.set('notAppliedOpts.request.host', hostname);
 				this.set('notAppliedOpts.request.path', pathname);
 				this.set('notAppliedOpts.request.query', search.replace('?', ''));
 			} catch (err) {
@@ -2058,7 +2057,6 @@
 
 				this.set('mainOptions.target', rawPasteContent);
 				this.set('httpOpts.protocol', defaultClientProtocol);
-				this.set('notAppliedOpts.request.host', '');
 				this.set('notAppliedOpts.request.path', '');
 				this.set('notAppliedOpts.request.query', '');
 			} finally {

--- a/src/views/pages/globalping.html
+++ b/src/views/pages/globalping.html
@@ -2044,7 +2044,7 @@
 				this.set('mainOptions.target', hostname);
 				this.set('httpOpts.protocol', protocol.replace(':', '').toUpperCase());
 				this.set('notAppliedOpts.port', port);
-				this.set('notAppliedOpts.request.path', pathname);
+				this.set('notAppliedOpts.request.path', pathname !== '/' ? pathname : '');
 				this.set('notAppliedOpts.request.query', search.replace('?', ''));
 			} catch (err) {
 				let { protocol: defaultClientProtocol } = this.getDefaultClientMeasOptsByTestName('http');

--- a/src/views/pages/globalping.html
+++ b/src/views/pages/globalping.html
@@ -1170,7 +1170,6 @@
 				// if so - should be a share-results logic implemented
 				let qsStringsArr = this.get('@shared.app.router.uri.qs').replace('?', '').split('&');
 				let { measurement: measurementId } = Object.fromEntries(qsStringsArr.map(s => s.split('=')));
-				let boundHandleTargetInputPaste = this.handleTargetInputPaste.bind(this);
 
 				if (measurementId) {
 					this.set('measurementId', measurementId);
@@ -1207,16 +1206,6 @@
 					this.set('notAppliedOpts', {});
 					this.set('testFailed', false);
 					this.set('modifiedMeasOptsCnt', 0);
-
-
-					// handle focus out of Target input while HTTP test
-					let targetInput = this.find('#targetInput');
-
-					if (type.toLowerCase() === 'http') {
-						targetInput.addEventListener('paste', boundHandleTargetInputPaste);
-					} else {
-						targetInput.removeEventListener('paste', boundHandleTargetInputPaste);
-					}
 				}, { init: false });
 
 				// handle join-network switch and commands content
@@ -1348,6 +1337,9 @@
 				if (measurementId) {
 					this.set('shareResultsCase', true);
 				}
+
+				let boundHandleTargetInputPaste = this.handleTargetInputPaste.bind(this);
+				targetInput.addEventListener('paste', boundHandleTargetInputPaste);
 			}
 		},
 		proceedToTest () {
@@ -2048,6 +2040,7 @@
 			try {
 				let { protocol, port, pathname, hostname, search } = new URL(rawPasteContent);
 
+				this.set('mainOptions.type', 'HTTP');
 				this.set('mainOptions.target', hostname);
 				this.set('httpOpts.protocol', protocol.replace(':', '').toUpperCase());
 				this.set('notAppliedOpts.port', port);
@@ -2057,10 +2050,13 @@
 				let { protocol: defaultClientProtocol } = this.getDefaultClientMeasOptsByTestName('http');
 
 				this.set('mainOptions.target', rawPasteContent);
-				this.set('httpOpts.protocol', defaultClientProtocol);
-				this.set('notAppliedOpts.request.path', '');
-				this.set('notAppliedOpts.request.query', '');
-				this.set('notAppliedOpts.port', '');
+
+				if (this.get('mainOptions.type') === 'HTTP') {
+					this.set('httpOpts.protocol', defaultClientProtocol);
+					this.set('notAppliedOpts.port', '');
+					this.set('notAppliedOpts.request.path', '');
+					this.set('notAppliedOpts.request.query', '');
+				}
 			} finally {
 				this.applyOptions();
 			}


### PR DESCRIPTION
Only for HTTP tests: when the user pastes a value into target try parsing it with new URL() - if valid, set path, query, port, and protocol options based on those values, and open the options popup so that the users sees it. Example: I paste https://www.jsdelivr.com/package/npm/react?tab=files I get: https://dl.dropboxusercontent.com/s/i56l8rsvx27gbzo/2023-05-16_14-37-14.png

Fix #538 