### PR TITLE
GpCredits: fix host-a-probe button

### DIFF
--- a/src/views/pages/globalping/credits.html
+++ b/src/views/pages/globalping/credits.html
@@ -136,7 +136,7 @@
 					</div>
 
 					<a class="gp_btn_green gp-credits_become-a-sponsor_block_btn"
-						on-click="@this.openLink('{{@shared.serverHost}}/#join-the-network')">
+						on-click="@this.openLink(@shared.serverHost + '/#join-the-network')">
 						Host a probe
 					</a>
 				</div>

--- a/test/tests/homepage.js
+++ b/test/tests/homepage.js
@@ -48,6 +48,7 @@ describe('homepage', () => {
 
 	it('top packages table loads', async () => {
 		await browser.navigate().to(`${BASE_URL}`);
+		await browser.sleep(1000);
 		await expect(browser.findElement({ css: '.stats-table-table :nth-child(2)' }).getText()).to.eventually.contain('npm');
 	});
 });


### PR DESCRIPTION
Fix the 'Host a Probe' link on the GpCredits page