### PR TITLE
GP: jumping numbers/text on the CLI page

### DIFF
--- a/src/assets/less/pages/globalping/cli.less
+++ b/src/assets/less/pages/globalping/cli.less
@@ -43,6 +43,16 @@
 					font-size: 40px;
 					line-height: 60px;
 				}
+
+				&_numbers {
+					display: inline-flex;
+					justify-content: flex-end;
+					width: 78px;
+
+					@media (min-width: @screen-sm-min) {
+						width: 120px;
+					}
+				}
 			}
 
 			&_descr {

--- a/src/views/pages/globalping/cli.html
+++ b/src/views/pages/globalping/cli.html
@@ -16,7 +16,7 @@
 			<h1 class="gp-cli_main-info_title">
 				Run network commands on a
 				<span class="gp-cli_green-text">
-					global network of {{ Math.floor(roundedTotalProbes) }}+ probes
+					global network of <span class="gp-cli_main-info_title_numbers">{{ Math.floor(roundedTotalProbes) }}+</span> probes
 				</span>
 				to test, debug and benchmark your infrastructure, routing and web services.
 			</h1>


### PR DESCRIPTION
Fix CLI page issue with jumping numbers/text at the top of the page