### PR TITLE
GP: Add OPTIONS as a supported HTTP method

### DIFF
--- a/src/views/pages/globalping/_index.html
+++ b/src/views/pages/globalping/_index.html
@@ -2314,6 +2314,11 @@
 								this.set('mainOptions.type', this.translateTestTypeName(testRes.type));
 								this.set('mainOptions.limit', testRes.limit || DEFAULT_LIMIT);
 
+								// handle map max timing for HTTP measurement
+								if (testRes.type.toLowerCase() === 'http') {
+									this.set('probesMaxTiming', 1000);
+								}
+
 								// ipVersion (target ip-type-switch) came with the measurementOptions but should be treated as the mainOptions
 								if (testRes.measurementOptions?.ipVersion) {
 									this.set('mainOptions.ipVersion', testRes.measurementOptions.ipVersion);

--- a/src/views/pages/globalping/_index.html
+++ b/src/views/pages/globalping/_index.html
@@ -436,6 +436,7 @@
 														<div class="dropdown-menu">
 															<div on-click="@this.set('httpOpts.request.method', 'GET')">GET</div>
 															<div on-click="@this.set('httpOpts.request.method', 'HEAD')">HEAD</div>
+															<div on-click="@this.set('httpOpts.request.method', 'OPTIONS')">OPTIONS</div>
 														</div>
 													</div>
 												</div>


### PR DESCRIPTION
Fix #723 
Also fixed an issue with the probe's max timing value during shared HTTP measurement.