### PR TITLE
Fix IPv6 share results measurement bug

### DIFF
--- a/src/views/components/tags-input.html
+++ b/src/views/components/tags-input.html
@@ -104,10 +104,16 @@
 		},
 		oninit () {
 			if (!Ractive.isServer) {
-				this.observe('error', () => {
-					this.set('invalidValue', this.get('value'));
-					this.set('ipVersion', null);
-					this.set('ipVersionDisplayed', null);
+				this.observe('error', (error) => {
+					if (error) {
+						this.set('invalidValue', this.get('value'));
+						this.set('ipVersion', null);
+						this.set('ipVersionDisplayed', null);
+					} else {
+						let tagsArr = this.get('tagsArr');
+
+						this.handleIpSwitchState(tagsArr[0]);
+					}
 				}, { init: false });
 
 				this.observe('value', (value) => {
@@ -149,24 +155,7 @@
 						return;
 					}
 
-					let ipv4regex = ipRegex.v4({ exact: true });
-					let ipv6regex = ipRegex.v6({ exact: true });
-
-					if (ipv4regex.test(tagsArr[0])) {
-						this.set('ipVersion', null);
-						this.set('ipVersionDisplayed', IP_V4_VALUE);
-						this.set('ipSwitchLocked', true);
-					} else if (ipv6regex.test(tagsArr[0])) {
-						this.set('ipVersion', null);
-						this.set('ipVersionDisplayed', IP_V6_VALUE);
-						this.set('ipSwitchLocked', true);
-					} else {
-						let ipVersionDisplayed = currIpVersionDisplayed || this.get('prevIpVersionDisplayed') || IP_V4_VALUE;
-
-						this.set('ipVersion', ipVersionDisplayed);
-						this.set('ipVersionDisplayed', ipVersionDisplayed);
-						this.set('ipSwitchLocked', false);
-					}
+					this.handleIpSwitchState(tagsArr[0]);
 				});
 
 				// set default value is it was passed as prop
@@ -420,5 +409,25 @@
 		handleIpTypeSwitchFocus (e, tagsBlockEl) {
 			tagsBlockEl.classList.remove('focused');
 		},
+		handleIpSwitchState (target) {
+			let ipv4regex = ipRegex.v4({ exact: true });
+			let ipv6regex = ipRegex.v6({ exact: true });
+
+			if (ipv4regex.test(target)) {
+				this.set('ipVersion', null);
+				this.set('ipVersionDisplayed', IP_V4_VALUE);
+				this.set('ipSwitchLocked', true);
+			} else if (ipv6regex.test(target)) {
+				this.set('ipVersion', null);
+				this.set('ipVersionDisplayed', IP_V6_VALUE);
+				this.set('ipSwitchLocked', true);
+			} else {
+				let ipVersionDisplayed = this.get('ipVersionDisplayed') || this.get('prevIpVersionDisplayed') || IP_V4_VALUE;
+
+				this.set('ipVersion', ipVersionDisplayed);
+				this.set('ipVersionDisplayed', ipVersionDisplayed);
+				this.set('ipSwitchLocked', false);
+			}
+		}
 	};
 </script>

--- a/src/views/components/tags-input.html
+++ b/src/views/components/tags-input.html
@@ -428,6 +428,6 @@
 				this.set('ipVersionDisplayed', ipVersionDisplayed);
 				this.set('ipSwitchLocked', false);
 			}
-		}
+		},
 	};
 </script>

--- a/src/views/pages/globalping/_index.html
+++ b/src/views/pages/globalping/_index.html
@@ -2321,7 +2321,10 @@
 
 								// ipVersion (target ip-type-switch) came with the measurementOptions but should be treated as the mainOptions
 								if (testRes.measurementOptions?.ipVersion) {
-									this.set('mainOptions.ipVersion', testRes.measurementOptions.ipVersion);
+									// if there is one target and it has IPv6 format (not a domain name) we shouldn't set ipVersion
+									if (updTargetsArr.length !== 1 || !ipRegex.v6({ exact: true }).test(updTargetsArr[0])) {
+										this.set('mainOptions.ipVersion', testRes.measurementOptions.ipVersion);
+									}
 
 									delete testRes.measurementOptions.ipVersion;
 								}


### PR DESCRIPTION
Fix #725 

Also, found another bug.
Bug description:
1. Set measurement type to DNS
2. Set target to some invalid value (not a domain name, IPv6 address for example)
3. Run measurement and get an error
4. Switch measurement type to Ping/HTTP/etc.
5. The IP type switch no longer appears
Fixed.