### PR TITLE
Load Fonts From jsDelivr

### DIFF
--- a/src/views/r-docs-globalping.html
+++ b/src/views/r-docs-globalping.html
@@ -61,7 +61,10 @@
 <!--			<link rel="preconnect" href="https://datum.jsdelivr.com/" crossorigin="anonymous">-->
 			<link rel="preconnect" href="https://fonts.googleapis.com" crossorigin="anonymous">
 
-			<link href="https://fonts.googleapis.com/css2?family=Lexend:wght@400;600;700&display=swap" rel="stylesheet">
+
+			<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fontsource/lexend@5.2.5/400.css" media="print" onload="this.media='all'">
+			<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fontsource/lexend@5.2.5/600.css" media="print" onload="this.media='all'">
+			<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fontsource/lexend@5.2.5/700.css" media="print" onload="this.media='all'">
 			<link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@500&display=swap" rel="stylesheet">
 			<link rel="stylesheet" href="{{@shared.assetsHost}}/css/app.css?v={{@shared.assetsVersion}}">
 			<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/font-awesome@4.7.0/css/font-awesome.min.css" media="print" onload="this.media='all'">

--- a/src/views/r-docs.html
+++ b/src/views/r-docs.html
@@ -63,7 +63,10 @@
 			<link rel="preconnect" href="https://datum.jsdelivr.com/" crossorigin="anonymous">
 			<link rel="preconnect" href="https://fonts.googleapis.com" crossorigin="anonymous">
 
-			<link href="https://fonts.googleapis.com/css2?family=Lexend:wght@400;600;700&display=swap" rel="stylesheet">
+
+			<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fontsource/lexend@5.2.5/400.css" media="print" onload="this.media='all'">
+			<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fontsource/lexend@5.2.5/600.css" media="print" onload="this.media='all'">
+			<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fontsource/lexend@5.2.5/700.css" media="print" onload="this.media='all'">
 			<link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@500&display=swap" rel="stylesheet">
 			<link rel="stylesheet" href="{{@shared.assetsHost}}/css/app.css?v={{@shared.assetsVersion}}">
 			<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/font-awesome@4.7.0/css/font-awesome.min.css" media="print" onload="this.media='all'">

--- a/src/views/r-page-globalping.html
+++ b/src/views/r-page-globalping.html
@@ -71,11 +71,13 @@
 <!--			<link rel="preconnect" href="https://datum.jsdelivr.com/" crossorigin="anonymous">-->
 			<link rel="preconnect" href="https://fonts.googleapis.com" crossorigin="anonymous">
 
-			<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lexend:wght@400;500;600&display=swap" media="print" onload="this.media='all'">
+			<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fontsource/lexend@5.2.5/400.css" media="print" onload="this.media='all'">
+			<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fontsource/lexend@5.2.5/500.css" media="print" onload="this.media='all'">
+			<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fontsource/lexend@5.2.5/600.css" media="print" onload="this.media='all'">
 			<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@500&display=swap" media="print" onload="this.media='all'">
 			<link rel="stylesheet" href="{{@shared.assetsHost}}/css/app.css?v={{@shared.assetsVersion}}">
 			<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/font-awesome@4.7.0/css/font-awesome.min.css" media="print" onload="this.media='all'">
-			<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter&display=swap" media="print" onload="this.media='all'">
+			<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fontsource/inter@5.2.5/400.css" media="print" onload="this.media='all'">
 
 			<link rel="sitemap" href="/sitemap/index.xml" type="application/xml">
 			{{yield css}}

--- a/src/views/r-page.html
+++ b/src/views/r-page.html
@@ -77,11 +77,13 @@
 			<link rel="preconnect" href="https://datum.jsdelivr.com/" crossorigin="anonymous">
 			<link rel="preconnect" href="https://fonts.googleapis.com" crossorigin="anonymous">
 
-			<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lexend:wght@400;500;600&display=swap" media="print" onload="this.media='all'">
+			<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fontsource/lexend@5.2.5/400.css" media="print" onload="this.media='all'">
+			<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fontsource/lexend@5.2.5/500.css" media="print" onload="this.media='all'">
+			<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fontsource/lexend@5.2.5/600.css" media="print" onload="this.media='all'">
 			<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@500&display=swap" media="print" onload="this.media='all'">
 			<link rel="stylesheet" href="{{@shared.assetsHost}}/css/app.css?v={{@shared.assetsVersion}}">
 			<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/font-awesome@4.7.0/css/font-awesome.min.css" media="print" onload="this.media='all'">
-			<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter&display=swap" media="print" onload="this.media='all'">
+			<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fontsource/inter@5.2.5/400.css" media="print" onload="this.media='all'">
 
 			<link rel="sitemap" href="/sitemap/index.xml" type="application/xml">
 			<link rel="search" href="/opensearch.xml" type="application/opensearchdescription+xml" title="jsDelivr">


### PR DESCRIPTION
Load fonts `Inter` and `Lexend` on `cdn.jsdelivr.net` from packages published by `@fontsource`.

Note that the `Source Code Pro` and `Open Sans` fonts are still loaded on Google Fonts since I can't find `Source Code Pro` with a weight of 500 and `Open Sans` with a weight of 200 on npm.