### PR TITLE
Add autocomplete for location field

### DIFF
--- a/elastic-apm-node.js
+++ b/elastic-apm-node.js
@@ -1,7 +1,7 @@
 module.exports = {
 	active: process.env.NODE_ENV === 'production',
 	serviceName: process.env.SITE === 'globalping' ? 'globalping-website' : 'jsdelivr-website',
-	serviceVersion: require('./package.json').version,
+	serviceVersion: process.env.RENDER_GIT_COMMIT || require('./package.json').version,
 	logLevel: 'fatal',
 	centralConfig: false,
 	captureExceptions: false,

--- a/src/assets/less/common-globalping.less
+++ b/src/assets/less/common-globalping.less
@@ -586,6 +586,15 @@
 			background: #f3f5f6;
 			border-radius: 8px 8px 0 0;
 			font-size: 13px;
+
+			code {
+				overflow-wrap: break-word;
+			}
+		}
+
+		.aa-gp-no-results {
+			padding: 12px;
+			color: #17233a;
 		}
 
 		.aa-Source {

--- a/src/assets/less/common-globalping.less
+++ b/src/assets/less/common-globalping.less
@@ -406,7 +406,7 @@
 	}
 
 	&_input {
-		> input, > textarea {
+		> input, > textarea, .aa-Input {
 			background: #fff;
 			border: 1.5px solid #e7e7ee;
 			box-shadow: 0 2px 2px rgba(0, 0, 0, .04);
@@ -548,5 +548,75 @@
 
 	100% {
 		transform: rotate(360deg);
+	}
+}
+
+.aa-InputWrapperPrefix, .aa-InputWrapperSuffix {
+	display: none;
+}
+
+.aa-gp-container {
+	width: 100%;
+}
+
+.aa-Panel {
+	position: absolute;
+	z-index: 1000;
+
+	.fa {
+		margin-right: 4px;
+	}
+
+	.aa-PanelLayout {
+		display: block;
+		width: 400px;
+		background-color: #fff;
+		border-radius: 8px;
+		border: 1.5px solid #e7e7ee;
+		box-shadow: 0 7px 36px rgba(0, 0, 0, .05);
+		padding: 0;
+		margin-top: 4px;
+
+		@media (max-width: 480px) {
+			width: 100%;
+		}
+
+		.aa-gp-info {
+			padding: 8px 12px;
+			background: #f3f5f6;
+			border-radius: 8px 8px 0 0;
+			font-size: 13px;
+		}
+
+		.aa-Source {
+			.aa-SourceHeader {
+				border-top: 1px solid #e7e7ee;
+				padding: 8px 12px 4px;
+				font-size: 12px;
+				color: #17233a;
+				opacity: .7;
+			}
+
+			.aa-List {
+				margin-bottom: 6px;
+				list-style: none;
+				padding: 0;
+
+				.aa-Item {
+					cursor: pointer;
+					padding: 4px 16px;
+
+					&[aria-selected="true"] {
+						background: #f3f5f7;
+					}
+
+					.aa-gp-item-extra, .aa-gp-item-count {
+						font-size: 12px;
+						color: #17233a;
+						opacity: .7;
+					}
+				}
+			}
+		}
 	}
 }

--- a/src/assets/less/common.less
+++ b/src/assets/less/common.less
@@ -598,3 +598,7 @@ body.noscroll {
 		}
 	}
 }
+
+.transition-none {
+	transition: none !important;
+}

--- a/src/assets/less/common.less
+++ b/src/assets/less/common.less
@@ -61,7 +61,7 @@ a, .fa {
 }
 
 // Global text input style
-input[type="text"], textarea {
+input[type="text"], input[type="search"], textarea {
 	transition: border 400ms;
 	font-size: 15px;
 	line-height: 22px;

--- a/src/assets/less/components/controlled-input.less
+++ b/src/assets/less/components/controlled-input.less
@@ -41,7 +41,7 @@
 		}
 	}
 
-	> input {
+	> input, .aa-Input {
 		border-radius: 8px;
 		height: 40px;
 		padding: 0 16px;

--- a/src/assets/less/components/gp-results-controls.less
+++ b/src/assets/less/components/gp-results-controls.less
@@ -19,7 +19,7 @@
 		flex-direction: column;
 		justify-content: flex-end;
 		width: 100%;
-		max-width: 1158px;
+		max-width: 1238px;
 
 		@media (min-width: @screen-sm-min) {
 			flex-direction: row;

--- a/src/assets/less/pages/esm.less
+++ b/src/assets/less/pages/esm.less
@@ -455,6 +455,38 @@
 			width: 100%;
 		}
 	}
+
+	.algolia-autocomplete {
+		.aa-hint {
+			color: #999;
+		}
+
+		.aa-dropdown-menu {
+			width: max-content; // stylelint-disable-line plugin/no-unsupported-browser-features
+			min-width: 200px;
+			background-color: #fff;
+			border: 1px solid rgba(0, 0, 0, .15);
+			border-top: none;
+			text-align: left;
+			font-family: @font-family-base;
+			-webkit-font-smoothing: antialiased;
+
+			.aa-suggestion {
+				cursor: pointer;
+				padding: 3px 20px;
+				font-size: 14px;
+
+				&.aa-cursor {
+					color: @dropdown-link-hover-color;
+					background-color: @c-orange;
+				}
+
+				p {
+					margin: 0;
+				}
+			}
+		}
+	}
 }
 
 .benchmark-iframe {
@@ -465,36 +497,4 @@
 	height: 0;
 	width: 0;
 	border: none;
-}
-
-.algolia-autocomplete {
-	.aa-hint {
-		color: #999;
-	}
-
-	.aa-dropdown-menu {
-		width: max-content; // stylelint-disable-line plugin/no-unsupported-browser-features
-		min-width: 200px;
-		background-color: #fff;
-		border: 1px solid rgba(0, 0, 0, .15);
-		border-top: none;
-		text-align: left;
-		font-family: @font-family-base;
-		-webkit-font-smoothing: antialiased;
-
-		.aa-suggestion {
-			cursor: pointer;
-			padding: 3px 20px;
-			font-size: 14px;
-
-			&.aa-cursor {
-				color: @dropdown-link-hover-color;
-				background-color: @c-orange;
-			}
-
-			p {
-				margin: 0;
-			}
-		}
-	}
 }

--- a/src/assets/less/pages/globalping.less
+++ b/src/assets/less/pages/globalping.less
@@ -159,7 +159,7 @@
 			z-index: 1;
 
 			@media (min-width: @screen-sm-min) {
-				max-width: 1224px;
+				max-width: 1304px;
 				margin: 0 auto;
 				width: calc(100% - 48px);
 				border: 1.5px solid #e7e7ee;
@@ -306,11 +306,11 @@
 							flex-shrink: 1;
 
 							&:nth-child(1) {
-								width: 60%;
+								width: 55%;
 							}
 
 							&:nth-child(2) {
-								width: calc(40% - 8px);
+								width: calc(45% - 8px);
 							}
 						}
 

--- a/src/views/components/gp-credits.html
+++ b/src/views/components/gp-credits.html
@@ -102,7 +102,7 @@
 				});
 
 				this.observe('rateCreditsData', (rateCreditsData) => {
-					if (rateCreditsData) {
+					if (rateCreditsData && rateCreditsData['x-ratelimit-limit']) {
 						let rateLimitConsumed = Number(rateCreditsData['x-ratelimit-consumed']) || 0;
 						let rateLimitRemaining = Number(rateCreditsData['x-ratelimit-remaining']) || 0;
 						let rateLimitLimit = Number(rateCreditsData['x-ratelimit-limit']) || 0;

--- a/src/views/components/gp-results-controls.html
+++ b/src/views/components/gp-results-controls.html
@@ -30,7 +30,7 @@
 
 			<div class="content-wrapper_ctrls_map-switch">
 				<span>Map: </span>
-				<div class="content-wrapper_ctrls_map-switch_switch" on-click="@this.set('showMap', !showMap)">
+				<div class="content-wrapper_ctrls_map-switch_switch" on-click="@this.set('showMap', !showMap),@this.set('originalShowMap', !showMap)">
 					<img width="16" height="16" src="{{@shared.assetsHost}}/img/globalping/map-icon{{#if showMap}}.active{{/if}}.svg">
 				</div>
 			</div>

--- a/src/views/components/gp-results-controls.html
+++ b/src/views/components/gp-results-controls.html
@@ -30,7 +30,7 @@
 
 			<div class="content-wrapper_ctrls_map-switch">
 				<span>Map: </span>
-				<div class="content-wrapper_ctrls_map-switch_switch" on-click="@this.set('showMap', !showMap),@this.set('originalShowMap', !showMap)">
+				<div class="content-wrapper_ctrls_map-switch_switch" on-click="@this.set('originalShowMap', !showMap),@this.set('showMap', !showMap)">
 					<img width="16" height="16" src="{{@shared.assetsHost}}/img/globalping/map-icon{{#if showMap}}.active{{/if}}.svg">
 				</div>
 			</div>

--- a/src/views/components/gp-results-share.html
+++ b/src/views/components/gp-results-share.html
@@ -130,7 +130,7 @@
 
 					if (params.locations && params.locations.length) {
 						let locationStr = params.locations.reduce((str, loc, idx) => {
-							let locPart = loc.magic.toLowerCase().trim();
+							let locPart = loc.magic.trim();
 
 							if (idx === 0) {
 								return str += locPart;

--- a/src/views/components/location-input.html
+++ b/src/views/components/location-input.html
@@ -39,6 +39,10 @@
 	const countries = require('../../assets/json/countries.json');
 	const continents = require('../../assets/json/continents.json');
 
+	const statesByCode = Object.fromEntries(states.map(state => [ state.code, state ]));
+	const countriesByCode = Object.fromEntries(countries.map(country => [ country.code, country ]));
+	const continentsByCode = Object.fromEntries(continents.map(continent => [ continent.code, continent ]));
+
 	const networkNameCleanupPattern = /[\s,]+(?:(?:\w{1,2}\.)+\w{0,2}|Ltd|Limited|Inc|Incorporated|Corp|Corporation|LLC|LLP|PLC|GmbH|S\.?\s?A\.?|Pty|Co|Company|AG|OÜ|ApS|A\/S|IVS|K\/S|AB|HB|KB|AS|ASA|ANS|NUF|Oy|Oyj|Ay|Ky|Tmi|EHF|HF|OHG|KG|GbR|BV|NV|VOF|Comm\.?\s?V|CV|SARL|SCA|SCS|ASBL|TÜ|MTÜ|FIE|Srl|SpA|SNC|SAS|EURL|UG|KGaA|SE|SCP|SCI|SARL-S|SCSp|Kft|Bt|Rt|Zrt|Nyrt|SIA|IK|PS|KS|ĀKF|BO|VSIA|VAS|UAB|VšĮ|IĮ|TŪB|KŪB|MB|BĮ|PP)[.,\s]*$/gi;
 	const escapeRegExp = string => string.replace(/[\\^$.*+?()[\]{}|]/g, '\\$&');
 
@@ -50,6 +54,7 @@
 			return {
 				invalidValue: null,
 				errMsgTopPos: false,
+				rawProbes: [],
 			};
 		},
 		oninit () {
@@ -81,15 +86,8 @@
 			window.addEventListener('resize', debounce(throttle(() => this.set('screenWidth', innerWidth), 200)));
 
 			if (!Ractive.isServer) {
-				let index = {
-					tags: [],
-					global: [],
-					cities: [],
-					countries: [],
-					continents: [],
-					regions: [],
-					networks: [],
-				};
+				let normalizedProbes;
+				let indexForConditions;
 
 				let initLimit = value => function runLimit (rawSources) {
 					let sources = rawSources.flat().filter(Boolean);
@@ -181,21 +179,47 @@
 						];
 					},
 					getSources ({ query }) {
-						let lastQuery = query.split(',').at(-1);
-						let queryGroup = lastQuery.split('+').map(q => q.trim()).filter(Boolean);
+						// The input allows several queries separated by a comma.
+						// Each query may have multiple parts separated by a plus sign.
+						// We always operate on the last part of the last query but need to preserve anything before it.
+						let queries = query.split(',');
+						let previousQueries = queries.length > 1 ? queries.slice(0, -1) : [];
+						let currentQuery = queries.at(-1);
 
-						let rankedPatternsPerGroup = queryGroup.map((query) => {
-							let escapedQuery = escapeRegExp(query);
+						let currentQueryParts = currentQuery.split('+');
+						let currentQueryPrevParts = currentQueryParts.length > 1 ? currentQueryParts.slice(0, -1) : [];
+						let currentQueryPrevPartsNormalized = currentQueryPrevParts.map(q => q.trim()).filter(v => v).map(s => s.toLowerCase()).sort();
+						let currentQueryPrevPartsNormalizedString = currentQueryPrevPartsNormalized.join('+');
+						let currentQueryCurrentPart = currentQueryParts.at(-1) || '';
+						let currentQueryCurrentPartLeadingWhitespace = currentQueryCurrentPart.match(/^\s+/)?.[0] || '';
+						let currentQueryCurrentPartTrimmed = currentQueryCurrentPart.trim();
 
-							return [
-								new RegExp(`^${escapedQuery}$`, 'im'),
-								new RegExp(`^${escapedQuery}\\b`, 'im'),
-								new RegExp(`^${escapedQuery}`, 'im'),
-								new RegExp(`\\b${escapedQuery}\\b`, 'im'),
-								new RegExp(`\\b${escapedQuery}`, 'im'),
-								new RegExp(`${escapedQuery}`, 'im'),
-							];
-						});
+						let escapedQuery = escapeRegExp(currentQueryCurrentPartTrimmed);
+						let queryPrefix = previousQueries.join(',');
+
+						if (queryPrefix) {
+							queryPrefix += ',';
+						}
+
+						if (currentQueryPrevParts.length) {
+							queryPrefix += `${currentQueryPrevParts.join('+')}+`;
+						}
+
+						queryPrefix += currentQueryCurrentPartLeadingWhitespace;
+
+						if (!indexForConditions[currentQueryPrevPartsNormalizedString]) {
+							createIndexFor(currentQueryPrevPartsNormalized);
+						}
+
+						let index = indexForConditions[currentQueryPrevPartsNormalizedString];
+						let rankedPatterns = escapedQuery ? [
+							new RegExp(`^${escapedQuery}$`, 'im'),
+							new RegExp(`^${escapedQuery}\\b`, 'im'),
+							new RegExp(`^${escapedQuery}`, 'im'),
+							new RegExp(`\\b${escapedQuery}\\b`, 'im'),
+							new RegExp(`\\b${escapedQuery}`, 'im'),
+							new RegExp(`${escapedQuery}`, 'im'),
+						] : [ /./ ];
 
 						let initSource = (name, properties) => {
 							return _.deepExtend({
@@ -204,7 +228,7 @@
 									return index[name];
 								},
 								getItemInputValue ({ item }) {
-									return item.value;
+									return queryPrefix + item.value;
 								},
 								templates: {
 									header () {
@@ -218,26 +242,21 @@
 							let filtered = [];
 							let bestRank = Infinity;
 
-							items:
 							for (let item of source.getItems()) {
-								let firstGroupRank = Infinity;
-
-								groups:
-								for (let rankedPatterns of rankedPatternsPerGroup) {
-									for (let i = 0; i < rankedPatterns.length; i++) {
-										if (rankedPatterns[i].test(item.normalizedValue)) {
-											firstGroupRank = i;
-											continue groups;
-										}
-									}
-
-									continue items;
+								if (item.count > index.countCap) {
+									continue;
 								}
 
-								filtered.push({ ...item, rank: firstGroupRank });
+								for (let i = 0; i < rankedPatterns.length; i++) {
+									if (rankedPatterns[i].test(item.normalizedValue)) {
+										filtered.push({ ...item, rank: i });
 
-								if (firstGroupRank < bestRank) {
-									bestRank = firstGroupRank;
+										if (i < bestRank) {
+											bestRank = i;
+										}
+
+										break;
+									}
 								}
 							}
 
@@ -353,7 +372,6 @@
 					this.set('swapInputs', true);
 				});
 
-
 				// Prepare the source data.
 				let uniqCountSortNormalize = (values) => {
 					let countValues = values.reduce((acc, value) => {
@@ -368,85 +386,134 @@
 					})).sort((a, b) => b.count - a.count);
 				};
 
-				this.observe('rawProbes', (probes) => {
+				let createNormalizedProbeList = (probes) => {
+					normalizedProbes = probes.map((probe) => {
+						let stateName = statesByCode[probe.location.state]?.name || probe.location.state;
+						let countryName = countriesByCode[probe.location.country]?.name || probe.location.country;
+						let continentName = continentsByCode[probe.location.continent]?.name || probe.location.continent;
+
+						let normalizedProbe = {
+							city: `${probe.location.city}\n${stateName ? `${stateName}\nUS-${probe.location.state}\n` : '\n\n'}${countryName}\n${probe.location.country}`,
+							region: probe.location.region,
+							state: stateName ? `${stateName}\nUS-${probe.location.state}` : '',
+							country: `${countryName}\n${probe.location.country}`,
+							continent: `${continentName}\n${probe.location.continent}`,
+							network: probe.location.network.replace(networkNameCleanupPattern, '').trim(),
+							tags: probe.tags.filter(tag => !tag.startsWith('u-')),
+						};
+
+						if (probe.location.country === 'GB') {
+							normalizedProbe.country += `\nUK\nGreat Britain\nEngland`.toLowerCase();
+						}
+
+						return {
+							...normalizedProbe,
+							allValues: Object.values(normalizedProbe).map(value => Array.isArray(value) ? value.join('\n').toLowerCase() : value.toLowerCase()).join('\n'),
+						};
+					});
+
+					indexForConditions = Object.create(null);
+				};
+
+				let createIndexFor = (conditions) => {
+					let index = {};
+
+					let filteredProbes = conditions.reduce((filteredProbes, condition) => {
+						let exactPattern = new RegExp(`(?:^|\n)${escapeRegExp(condition)}(?:$|\n)`, 'm');
+
+						let exactMatchFound = false;
+						let looseMatchFound = false;
+
+						filteredProbes = filteredProbes.filter((probe) => {
+							if (!probe.allValues.includes(condition)) {
+								return false;
+							}
+
+							if (exactPattern.test(probe.allValues)) {
+								exactMatchFound = true;
+							} else {
+								looseMatchFound = true;
+							}
+
+							return true;
+						});
+
+						if (exactMatchFound && looseMatchFound) {
+							filteredProbes = filteredProbes.filter(probe => exactPattern.test(probe.allValues));
+						}
+
+						return filteredProbes;
+					}, normalizedProbes);
+
 					index.global = [
 						'World',
 					];
 
-					index.cities = probes.map(probe => `${probe.location.city}\n${probe.location.state}\n${probe.location.country}`);
-					index.countries = probes.map(probe => probe.location.country);
-					index.continents = probes.map(probe => probe.location.continent);
-					index.regions = probes.map(probe => probe.location.region);
-					index.states = probes.map(probe => probe.location.state).filter(v => v);
-					index.tags = probes.map(probe => probe.tags.filter(tag => !tag.startsWith('u-'))).flat();
-
-					index.networks = probes.map(probe => probe.location.network).map((network) => {
-						return network.replace(networkNameCleanupPattern, '').trim();
-					}).filter(network => !network.includes(','));
+					index.tags = filteredProbes.map(probe => probe.tags).flat();
+					index.cities = filteredProbes.map(probe => probe.city);
+					index.countries = filteredProbes.map(probe => probe.country);
+					index.continents = filteredProbes.map(probe => probe.continent);
+					index.regions = filteredProbes.map(probe => probe.region);
+					index.states = filteredProbes.map(probe => probe.state).filter(v => v);
+					index.networks = filteredProbes.map(probe => probe.network).filter(network => network && !network.includes(','));
 
 					Object.keys(index).forEach((key) => {
 						index[key] = uniqCountSortNormalize(index[key]);
 					});
 
 					index.cities = index.cities.map((cityRow) => {
-						let [ city, stateCode, countryCode ] = cityRow.value.split('\n');
-						let country = countries.find(c => c.code === countryCode).name || countryCode;
-						let stateName = states.find(s => s.code === stateCode)?.name || '';
+						let [ city, stateName, stateCode, countryName, countryCode ] = cityRow.value.split('\n');
 
 						return {
 							...cityRow,
-							value: `${city}+${stateName ? `US-${stateCode}` : countryCode}`,
-							normalizedValue: `${city}\n${stateName ? `${stateName}\nUS-${stateCode}\n${stateCode}\n` : ''}${country}\n${countryCode}`.toLowerCase(),
+							value: `${city}+${stateName ? stateCode : countryCode}`,
 							displayValue: `${city}`,
-							country: `${country} (${countryCode})`,
-							state: stateName ? `${stateName} (US-${stateCode})` : '',
+							country: `${countryName} (${countryCode})`,
+							state: stateName ? `${stateName} (${stateCode})` : '',
 						};
 					});
 
-					index.countries = index.countries.map((country) => {
-						let value = countries.find(c => c.code === country.value).name || country.value;
+					index.countries = index.countries.map((countryRow) => {
+						let [ countryName, countryCode ] = countryRow.value.split('\n');
 
 						return {
-							...country,
-							value,
-							normalizedValue: `${value}\n${country.normalizedValue}`.toLowerCase(),
-							countryCode: country.value,
+							...countryRow,
+							value: countryName,
+							countryCode,
 						};
-					}).map((country) => {
-						if (country.countryCode === 'GB') {
-							return {
-								...country,
-								normalizedValue: `${country.value}\nUK\nGreat Britain\nEngland`.toLowerCase(),
-							};
-						}
-
-						return country;
 					});
 
-					index.continents = index.continents.map((continent) => {
-						let value = continents.find(c => c.code === continent.value).name || continent.value;
+					index.continents = index.continents.map((continentRow) => {
+						let [ continentName ] = continentRow.value.split('\n');
 
 						return {
-							...continent,
-							value,
-							normalizedValue: `${value}\n${continent.value}`.toLowerCase(),
+							...continentRow,
+							value: continentName,
 						};
 					});
 
-					index.states = index.states.map((state) => {
-						let name = states.find(c => c.code === state.value).name || state.value;
+					index.states = index.states.map((stateRow) => {
+						let [ stateName, stateCode ] = stateRow.value.split('\n');
 
 						return {
-							...state,
-							value: `US-${state.value}`,
-							displayValue: name,
-							normalizedValue: `${name}\nUS-${state.value}\n${state.value}\nUnited States\nUS`.toLowerCase(),
-							stateCode: `US-${state.value}`,
+							...stateRow,
+							value: stateCode,
+							displayValue: stateName,
+							stateCode,
 						};
 					});
+
+					index.count = filteredProbes.length;
+					index.countCap = conditions.length ? index.count - 1 : index.count;
 
 					index.tags.unshift(...index.global);
-					index.tags[0].count = probes.length;
+					index.tags[0].count = filteredProbes.length;
+
+					indexForConditions[conditions.join('+')] = index;
+				};
+
+				this.observe('rawProbes', (probes) => {
+					createNormalizedProbeList(probes);
 				});
 			}
 		},

--- a/src/views/components/location-input.html
+++ b/src/views/components/location-input.html
@@ -177,6 +177,9 @@
 
 						this.set('value', state.isOpen ? state.query : state.completion || state.query);
 					},
+					onSubmit: () => {
+						this.fire('enter');
+					},
 					detachedMediaQuery: 'none',
 					placeholder: this.get('placeholder'),
 					openOnFocus: true,

--- a/src/views/components/location-input.html
+++ b/src/views/components/location-input.html
@@ -288,7 +288,7 @@
 							let bestRank = Infinity;
 
 							for (let item of source.getItems()) {
-								if ((source.sourceId !== 'cities' || !index.countCap) && item.count > index.countCap) {
+								if (item.count > index.countCap && (!index.countCap || source.sourceId !== 'cities' || source.getItemInputValue({ item }) === queryPrefix)) {
 									continue;
 								}
 

--- a/src/views/components/location-input.html
+++ b/src/views/components/location-input.html
@@ -288,7 +288,7 @@
 							let bestRank = Infinity;
 
 							for (let item of source.getItems()) {
-								if (source.sourceId !== 'cities' && item.count > index.countCap) {
+								if ((source.sourceId !== 'cities' || !index.countCap) && item.count > index.countCap) {
 									continue;
 								}
 

--- a/src/views/components/location-input.html
+++ b/src/views/components/location-input.html
@@ -164,6 +164,20 @@
 							root,
 						);
 					},
+					renderNoResults ({ html, render, state }, root) {
+						return render(html`
+							<div class="aa-PanelLayout">
+								<section class="aa-gp-info">
+									Search for <code>${state.query}</code> across all probes.
+								</section>
+
+								<div class="aa-gp-no-results">
+									Our magic search supports names of continents, regions, countries, US states, cities, networks, and custom tags.<br/><br/>
+									Use <code>+</code> to combine multiple filters, and <code>,</code> to select multiple locations.
+								</div>
+							</div>
+						`, root);
+					},
 					reshape ({ sources }) {
 						return [
 							limit(sources),

--- a/src/views/components/location-input.html
+++ b/src/views/components/location-input.html
@@ -252,7 +252,7 @@
 						let index = indexForConditions[currentQueryPrevPartsNormalizedString];
 						let rankedPatterns = escapedQuery ? [
 							new RegExp(`^${escapedQuery}$`, 'im'),
-							new RegExp(`^${escapedQuery}\\b`, 'im'),
+							// new RegExp(`^${escapedQuery}\\b`, 'im'),
 							new RegExp(`^${escapedQuery}`, 'im'),
 							new RegExp(`\\b${escapedQuery}\\b`, 'im'),
 							new RegExp(`\\b${escapedQuery}`, 'im'),

--- a/src/views/components/location-input.html
+++ b/src/views/components/location-input.html
@@ -39,7 +39,7 @@
 	const countries = require('../../assets/json/countries.json');
 	const continents = require('../../assets/json/continents.json');
 
-	const statesByCode = Object.fromEntries(states.map(state => [ state.code, state ]));
+	const statesByCode = Object.fromEntries(states.map(state => [ `US-${state.code}`, state ]));
 	const countriesByCode = Object.fromEntries(countries.map(country => [ country.code, country ]));
 	const continentsByCode = Object.fromEntries(continents.map(continent => [ continent.code, continent ]));
 
@@ -464,14 +464,13 @@
 
 				let createNormalizedProbeList = (probes) => {
 					normalizedProbes = probes.map((probe) => {
-						let stateName = statesByCode[probe.location.state]?.name || probe.location.state;
 						let countryName = countriesByCode[probe.location.country]?.name || probe.location.country;
 						let continentName = continentsByCode[probe.location.continent]?.name || probe.location.continent;
 
 						let normalizedProbe = {
-							city: `${probe.location.city}\n${stateName ? `${stateName}\nUS-${probe.location.state}\n` : '\n\n'}${countryName}\n${probe.location.country}`,
+							city: `${probe.location.city}\n${probe.location.state ? `US-${probe.location.state}\n` : '\n'}${countryName}\n${probe.location.country}`,
 							region: probe.location.region,
-							state: stateName ? `${stateName}\nUS-${probe.location.state}` : '',
+							state: probe.location.state ? `US-${probe.location.state}` : '',
 							country: `${countryName}\n${probe.location.country}`,
 							continent: `${continentName}\n${probe.location.continent}`,
 							network: probe.location.network.replace(networkNameCleanupPattern, '').trim(),
@@ -538,11 +537,13 @@
 					});
 
 					index.cities = index.cities.map((cityRow) => {
-						let [ city, stateName, stateCode, countryName, countryCode ] = cityRow.value.split('\n');
+						let [ city, stateCode, countryName, countryCode ] = cityRow.value.split('\n');
+						let stateName = statesByCode[stateCode]?.name || stateCode;
 
 						return {
 							...cityRow,
-							value: `${city}+${stateName ? stateCode : countryCode}`,
+							value: `${city}+${stateCode || countryCode}`,
+							normalizedValue: `${cityRow.normalizedValue}\n${stateName.toLowerCase()}`,
 							displayValue: `${city}`,
 							country: `${countryName} (${countryCode})`,
 							state: stateName ? `${stateName} (${stateCode})` : '',
@@ -571,11 +572,13 @@
 					});
 
 					index.states = index.states.map((stateRow) => {
-						let [ stateName, stateCode ] = stateRow.value.split('\n');
+						let stateCode = stateRow.value;
+						let stateName = statesByCode[stateCode]?.name || stateCode;
 
 						return {
 							...stateRow,
 							value: stateCode,
+							normalizedValue: `${stateRow.normalizedValue}\n${stateName.toLowerCase()}`,
 							displayValue: stateName,
 							stateCode,
 						};

--- a/src/views/components/location-input.html
+++ b/src/views/components/location-input.html
@@ -142,11 +142,41 @@
 				`;
 
 				let limit = initLimit(12);
-				let { autocomplete } = window['@algolia/autocomplete-js'];
+				let { autocomplete, destroy } = window['@algolia/autocomplete-js'];
 
-				let { setQuery } = autocomplete({
+				let customTabHandlingActive = false;
+				let overrideState = false;
+				let isAsyncOpen = false;
+
+				let activeItemId;
+				let currentCompletion;
+				let currentCollections;
+
+				let { setQuery, setActiveItemId } = autocomplete({
 					container: this.find('.aa-gp-container'),
-					onStateChange: ({ state }) => { this.set('value', state.isOpen ? state.query : state.completion || state.query); },
+					onStateChange: ({ state }) => {
+						activeItemId = state.activeItemId;
+						setTimeout(() => isAsyncOpen = state.isOpen);
+
+						if (overrideState) {
+							overrideState = false;
+							return;
+						}
+
+						if (state.isOpen) {
+							currentCompletion = state.completion;
+							currentCollections = state.collections;
+
+							if (state.query && !currentCompletion && activeItemId === null) {
+								setActiveItemId(0);
+								customTabHandlingActive = true;
+							} else if (state.activeItemId !== 0) {
+								customTabHandlingActive = false;
+							}
+						}
+
+						this.set('value', state.isOpen ? state.query : state.completion || state.query);
+					},
 					detachedMediaQuery: 'none',
 					placeholder: this.get('placeholder'),
 					openOnFocus: true,
@@ -346,15 +376,36 @@
 
 				let input = this.el.querySelector('.aa-Input');
 
-				// Enter handling.
-				let handleEnterBtn = (event) => {
-					if (event.key === 'Enter') {
+				// Enter handling - run the measurement.
+				let handleEnter = (event) => {
+					if (event.key === 'Enter' && !isAsyncOpen) {
 						this.fire('enter');
 					}
 				};
 
-				input.addEventListener('keypress', handleEnterBtn);
-				this.on('unrender', () => input.removeEventListener('keypress', handleEnterBtn));
+				input.addEventListener('keydown', handleEnter);
+				this.on('unrender', () => input.removeEventListener('keydown', handleEnter));
+
+				// Tab handling - autocomplete.
+				let handleTab = (event) => {
+					if (event.key === 'Tab' && customTabHandlingActive) {
+						let firstItem = currentCollections.find(c => c.items.length)?.items[0];
+
+						if (firstItem) {
+							setQuery(firstItem.value);
+						}
+					} else if ([ 'ArrowDown', 'ArrowUp' ].includes(event.key)) {
+						// Preserve the original unfinished query at "null" position (default behavior without our modifications).
+						if (activeItemId === 0 && !currentCompletion) {
+							overrideState = true;
+							customTabHandlingActive = false;
+							setActiveItemId(null);
+						}
+					}
+				};
+
+				input.addEventListener('keydown', handleTab);
+				this.on('unrender', () => input.removeEventListener('keydown', handleTab));
 
 				// Propagate state changes.
 				this.observe('value', (newValue) => {
@@ -520,6 +571,8 @@
 				this.observe('rawProbes', (probes) => {
 					createNormalizedProbeList(probes);
 				});
+
+				this.on('unrender', () => destroy());
 			}
 		},
 	};

--- a/src/views/components/location-input.html
+++ b/src/views/components/location-input.html
@@ -266,7 +266,14 @@
 									return index[name];
 								},
 								getItemInputValue ({ item }) {
-									return queryPrefix + item.value;
+									// Some items have multiple valid ways to refer to them, e.g., EU and Europe. Preserve the existing value in that case.
+									let allowedValue = item.inputValues?.find(v => v.toLowerCase() === currentQueryCurrentPartTrimmed.toLowerCase());
+
+									// Cities are composed of two parts, which requires special handling to avoid duplicating one of them.
+									let valueToAdd = allowedValue || item.value;
+									let partsToAdd = valueToAdd.split('+').filter(v => !currentQueryPrevPartsNormalized.includes(v.toLowerCase()));
+
+									return queryPrefix + partsToAdd.join('+');
 								},
 								templates: {
 									header () {
@@ -281,7 +288,7 @@
 							let bestRank = Infinity;
 
 							for (let item of source.getItems()) {
-								if (item.count > index.countCap) {
+								if (source.sourceId !== 'cities' && item.count > index.countCap) {
 									continue;
 								}
 
@@ -392,10 +399,10 @@
 				// Tab handling - autocomplete.
 				let handleTab = (event) => {
 					if (event.key === 'Tab' && customTabHandlingActive) {
-						let firstItem = currentCollections.find(c => c.items.length)?.items[0];
+						let collection = currentCollections.find(c => c.items.length);
 
-						if (firstItem) {
-							setQuery(firstItem.value);
+						if (collection) {
+							setQuery(collection.source.getItemInputValue({ item: collection.items[0] }));
 						}
 					} else if ([ 'ArrowDown', 'ArrowUp' ].includes(event.key)) {
 						// Preserve the original unfinished query at "null" position (default behavior without our modifications).
@@ -548,16 +555,18 @@
 						return {
 							...countryRow,
 							value: countryName,
+							inputValues: [ countryName, countryCode ],
 							countryCode,
 						};
 					});
 
 					index.continents = index.continents.map((continentRow) => {
-						let [ continentName ] = continentRow.value.split('\n');
+						let [ continentName, continentCode ] = continentRow.value.split('\n');
 
 						return {
 							...continentRow,
 							value: continentName,
+							inputValues: [ continentName, continentCode ],
 						};
 					});
 

--- a/src/views/components/location-input.html
+++ b/src/views/components/location-input.html
@@ -188,7 +188,7 @@
 						render(
 							html`
 							<div class="aa-PanelLayout aa-Panel--scrollable">
-								<section class="aa-gp-info"><i class="fa fa-lightbulb-o" aria-hidden="true"></i> Try one of these suggestions or use your own value</section>
+								<section class="aa-gp-info"><i class="fa fa-lightbulb-o" aria-hidden="true"></i> Try one of these suggestions or use your own value.</section>
 								${sections}
 							</div>`,
 							root,
@@ -406,6 +406,16 @@
 
 				input.addEventListener('keydown', handleTab);
 				this.on('unrender', () => input.removeEventListener('keydown', handleTab));
+
+				// Focus handling - select the text.
+				let handleFocus = () => {
+					if (this.get('value').toLowerCase() === 'world') {
+						input.select();
+					}
+				};
+
+				input.addEventListener('focus', handleFocus);
+				this.on('unrender', () => input.removeEventListener('focus', handleFocus));
 
 				// Propagate state changes.
 				this.observe('value', (newValue) => {

--- a/src/views/components/location-input.html
+++ b/src/views/components/location-input.html
@@ -134,14 +134,6 @@
 					return limitedSources;
 				};
 
-				let initNonEqual = isEqual => function runNonEqual (query, rawSources) {
-					let sources = rawSources.flat().filter(Boolean).filter((source) => {
-						return !(!source.count || (source.count === 1 && isEqual(query, source.getItems()[0])));
-					});
-
-					return sources.length ? rawSources : [];
-				};
-
 				let columns = (html, left, right) => html`
 					<div style="display: flex; justify-content: space-between; align-items: center; width: 100%;">
 						<div>${left}</div>
@@ -150,7 +142,6 @@
 				`;
 
 				let limit = initLimit(12);
-				let nonEqual = initNonEqual((query, item) => item.normalizedValue === query.toLowerCase());
 				let { autocomplete } = window['@algolia/autocomplete-js'];
 
 				let { setQuery } = autocomplete({
@@ -173,9 +164,9 @@
 							root,
 						);
 					},
-					reshape ({ sources, state }) {
+					reshape ({ sources }) {
 						return [
-							limit(nonEqual(state.query, sources)),
+							limit(sources),
 						];
 					},
 					getSources ({ query }) {

--- a/src/views/components/location-input.html
+++ b/src/views/components/location-input.html
@@ -1,0 +1,454 @@
+<div class="c-controlled-input {{classList}}">
+	<div class="c-controlled-input_info">
+		<span class="c-controlled-input_info_label">
+			{{labelText}}
+			{{#if @this.partials.labelIcon && !hideLabelIcon}}
+				{{>labelIcon}}
+			{{/if}}
+		</span>
+
+		{{#if error}}
+			<span class="c-controlled-input_info_errorMsg">
+				{{error}}
+			</span>
+
+			<img class="c-controlled-input_err-icon"
+				width="20"
+				height="20"
+				src="{{@shared.assetsHost}}/img/globalping/alert-icon.svg">
+		{{/if}}
+	</div>
+
+	<!-- Use a server-rendered input and swap it for the real on init to avoid having visible empty space here during init. -->
+	<input
+		type="text"
+		value="{{value}}"
+		placeholder="{{placeholder}}"
+		class="{{#if swapInputs}}hidden{{/if}}">
+
+	<div class="aa-gp-container {{#unless swapInputs}}hidden{{/unless}}"></div>
+</div>
+
+<script>
+	const _ = require('../../assets/js/_');
+	const debounce = require('../../assets/js/utils/debounce');
+	const throttle = require('../../assets/js/utils/throttle');
+	const tooltip = require('../../assets/js/decorators/tooltip');
+
+	const states = require('../../assets/json/usa-states.json');
+	const countries = require('../../assets/json/countries.json');
+	const continents = require('../../assets/json/continents.json');
+
+	const networkNameCleanupPattern = /[\s,]+(?:(?:\w{1,2}\.)+\w{0,2}|Ltd|Limited|Inc|Incorporated|Corp|Corporation|LLC|LLP|PLC|GmbH|S\.?\s?A\.?|Pty|Co|Company|AG|OÜ|ApS|A\/S|IVS|K\/S|AB|HB|KB|AS|ASA|ANS|NUF|Oy|Oyj|Ay|Ky|Tmi|EHF|HF|OHG|KG|GbR|BV|NV|VOF|Comm\.?\s?V|CV|SARL|SCA|SCS|ASBL|TÜ|MTÜ|FIE|Srl|SpA|SNC|SAS|EURL|UG|KGaA|SE|SCP|SCI|SARL-S|SCSp|Kft|Bt|Rt|Zrt|Nyrt|SIA|IK|PS|KS|ĀKF|BO|VSIA|VAS|UAB|VšĮ|IĮ|TŪB|KŪB|MB|BĮ|PP)[.,\s]*$/gi;
+	const escapeRegExp = string => string.replace(/[\\^$.*+?()[\]{}|]/g, '\\$&');
+
+	component.exports = {
+		decorators: {
+			tooltip,
+		},
+		data () {
+			return {
+				invalidValue: null,
+				errMsgTopPos: false,
+			};
+		},
+		oninit () {
+			if (!Ractive.isServer) {
+				this.observeOnce('error', () => {
+					this.set('invalidValue', this.get('value'));
+				}, { init: false });
+
+				this.observe('value', (value) => {
+					let invalidValue = this.get('invalidValue');
+					let error = this.get('error');
+
+					if (error && invalidValue !== value) {
+						this.set('error', undefined);
+					}
+				});
+
+				this.observe('screenWidth', (screenWidth) => {
+					if ((screenWidth || innerWidth) < 768) {
+						this.set('errMsgTopPos', true);
+					} else {
+						this.set('errMsgTopPos', false);
+					}
+				});
+			}
+		},
+		onrender () {
+			// detect window resize
+			window.addEventListener('resize', debounce(throttle(() => this.set('screenWidth', innerWidth), 200)));
+
+			if (!Ractive.isServer) {
+				let index = {
+					tags: [],
+					global: [],
+					cities: [],
+					countries: [],
+					continents: [],
+					regions: [],
+					networks: [],
+				};
+
+				let initLimit = value => function runLimit (rawSources) {
+					let sources = rawSources.flat().filter(Boolean);
+					let nonEmptySources = 0;
+					let totalItems = 0;
+
+					sources.forEach((source) => {
+						nonEmptySources += source.count ? 1 : 0;
+						totalItems += source.count;
+					});
+
+					if (totalItems === 0) {
+						return [];
+					}
+
+					let minLimitPerSource = Math.ceil(value / nonEmptySources);
+					let maxLimitPerSource = Math.max(Math.min(totalItems, value), minLimitPerSource);
+					let limitedSources;
+
+					for (let currentLimit = minLimitPerSource; currentLimit <= maxLimitPerSource; currentLimit++) {
+						let sharedLimitRemaining = value;
+
+						limitedSources = sources.map((source, index) => {
+							let isLastSource = index === sources.length - 1;
+							let sourceLimit = isLastSource
+								? sharedLimitRemaining
+								: Math.min(currentLimit, sharedLimitRemaining);
+							let items = source.getItems().slice(0, sourceLimit);
+							sharedLimitRemaining = Math.max(sharedLimitRemaining - items.length, 0);
+
+							return {
+								...source,
+								getItems () {
+									return items;
+								},
+							};
+						});
+
+						if (!sharedLimitRemaining) {
+							return limitedSources;
+						}
+					}
+
+					return limitedSources;
+				};
+
+				let initNonEqual = isEqual => function runNonEqual (query, rawSources) {
+					let sources = rawSources.flat().filter(Boolean).filter((source) => {
+						return !(!source.count || (source.count === 1 && isEqual(query, source.getItems()[0])));
+					});
+
+					return sources.length ? rawSources : [];
+				};
+
+				let columns = (html, left, right) => html`
+					<div style="display: flex; justify-content: space-between; align-items: center; width: 100%;">
+						<div>${left}</div>
+						<div class="aa-gp-item-count">${right}</div>
+					</div>
+				`;
+
+				let limit = initLimit(12);
+				let nonEqual = initNonEqual((query, item) => item.normalizedValue === query.toLowerCase());
+				let { autocomplete } = window['@algolia/autocomplete-js'];
+
+				let { setQuery } = autocomplete({
+					container: this.find('.aa-gp-container'),
+					onStateChange: ({ state }) => { this.set('value', state.isOpen ? state.query : state.completion || state.query); },
+					detachedMediaQuery: 'none',
+					placeholder: this.get('placeholder'),
+					openOnFocus: true,
+					classNames: {
+						panelLayout: 'dropdown-menu',
+						input: this.get('error') ? 'has-error' : '',
+					},
+					render ({ sections, render, html }, root) {
+						render(
+							html`
+							<div class="aa-PanelLayout aa-Panel--scrollable">
+								<section class="aa-gp-info"><i class="fa fa-lightbulb-o" aria-hidden="true"></i> Try one of these suggestions or use your own value</section>
+								${sections}
+							</div>`,
+							root,
+						);
+					},
+					reshape ({ sources, state }) {
+						return [
+							limit(nonEqual(state.query, sources)),
+						];
+					},
+					getSources ({ query }) {
+						let lastQuery = query.split(',').at(-1);
+						let queryGroup = lastQuery.split('+').map(q => q.trim()).filter(Boolean);
+
+						let rankedPatternsPerGroup = queryGroup.map((query) => {
+							let escapedQuery = escapeRegExp(query);
+
+							return [
+								new RegExp(`^${escapedQuery}$`, 'im'),
+								new RegExp(`^${escapedQuery}\\b`, 'im'),
+								new RegExp(`^${escapedQuery}`, 'im'),
+								new RegExp(`\\b${escapedQuery}\\b`, 'im'),
+								new RegExp(`\\b${escapedQuery}`, 'im'),
+								new RegExp(`${escapedQuery}`, 'im'),
+							];
+						});
+
+						let initSource = (name, properties) => {
+							return _.deepExtend({
+								sourceId: name,
+								getItems: () => {
+									return index[name];
+								},
+								getItemInputValue ({ item }) {
+									return item.value;
+								},
+								templates: {
+									header () {
+										return _.capitalizeFirstLetter(name);
+									},
+								},
+							}, properties);
+						};
+
+						let filterSourceResults = (source) => {
+							let filtered = [];
+							let bestRank = Infinity;
+
+							items:
+							for (let item of source.getItems()) {
+								let firstGroupRank = Infinity;
+
+								groups:
+								for (let rankedPatterns of rankedPatternsPerGroup) {
+									for (let i = 0; i < rankedPatterns.length; i++) {
+										if (rankedPatterns[i].test(item.normalizedValue)) {
+											firstGroupRank = i;
+											continue groups;
+										}
+									}
+
+									continue items;
+								}
+
+								filtered.push({ ...item, rank: firstGroupRank });
+
+								if (firstGroupRank < bestRank) {
+									bestRank = firstGroupRank;
+								}
+							}
+
+							filtered.sort((a, b) => {
+								if (a.rank === b.rank) {
+									return b.count - a.count;
+								}
+
+								return a.rank - b.rank;
+							});
+
+							return {
+								...source,
+								getItems: () => filtered,
+								count: filtered.length,
+								rank: bestRank,
+							};
+						};
+
+						return [
+							initSource('tags', {
+								templates: {
+									item ({ item, html }) {
+										return columns(html, item.value, `${item.count}`);
+									},
+								},
+							}),
+							initSource('countries', {
+								templates: {
+									item ({ item, html }) {
+										return columns(html, html`${item.value}<span class="aa-gp-item-extra"> (${item.countryCode})</span>`, `${item.count}`);
+									},
+								},
+							}),
+							initSource('continents', {
+								templates: {
+									item ({ item, html }) {
+										return columns(html, `${item.value}`, `${item.count}`);
+									},
+								},
+							}),
+							initSource('cities', {
+								templates: {
+									item ({ item, html }) {
+										return columns(html, html`${item.displayValue}<span class="aa-gp-item-extra">, ${item.state || item.country}</span>`, `${item.count}`);
+									},
+								},
+							}),
+							initSource('regions', {
+								templates: {
+									item ({ item, html }) {
+										return columns(html, `${item.value}`, `${item.count}`);
+									},
+								},
+							}),
+							initSource('states', {
+								templates: {
+									item ({ item, html }) {
+										return columns(html, html`${item.displayValue}<span class="aa-gp-item-extra"> (${item.stateCode})</span>`, `${item.count}`);
+									},
+								},
+							}),
+							initSource('networks', {
+								templates: {
+									item ({ item, html }) {
+										return columns(html, `${item.value}`, `${item.count}`);
+									},
+								},
+							}),
+						].map((source) => {
+							return filterSourceResults(source);
+						}).sort((a, b) => {
+							// For sections with the same rank, order by the number of probes in the first location.
+							if (a.rank === b.rank) {
+								return (b.getItems()[0]?.count || 0) - (a.getItems()[0]?.count || 0);
+							}
+
+							return a.rank - b.rank;
+						});
+					},
+				});
+
+				let input = this.el.querySelector('.aa-Input');
+
+				// Enter handling.
+				let handleEnterBtn = (event) => {
+					if (event.key === 'Enter') {
+						this.fire('enter');
+					}
+				};
+
+				input.addEventListener('keypress', handleEnterBtn);
+				this.on('unrender', () => input.removeEventListener('keypress', handleEnterBtn));
+
+				// Propagate state changes.
+				this.observe('value', (newValue) => {
+					setQuery(newValue);
+				}, { init: false });
+
+				this.observe('disabled', (newValue) => {
+					input.classList.toggle('is-disabled', !!newValue);
+					input.disabled = !!newValue;
+				}, { init: false });
+
+				this.observe('error', (newValue) => {
+					input.classList.toggle('has-error', !!newValue);
+				}, { init: false });
+
+				// Fill in the initial value and show the input.
+				setQuery(this.get('value') || '');
+
+				setTimeout(() => {
+					this.set('swapInputs', true);
+				});
+
+
+				// Prepare the source data.
+				let uniqCountSortNormalize = (values) => {
+					let countValues = values.reduce((acc, value) => {
+						acc[value] = (acc[value] || 0) + 1;
+						return acc;
+					}, {});
+
+					return Object.keys(countValues).map(key => ({
+						value: key,
+						normalizedValue: key.toLowerCase(),
+						count: countValues[key],
+					})).sort((a, b) => b.count - a.count);
+				};
+
+				this.observe('rawProbes', (probes) => {
+					index.global = [
+						'World',
+					];
+
+					index.cities = probes.map(probe => `${probe.location.city}\n${probe.location.state}\n${probe.location.country}`);
+					index.countries = probes.map(probe => probe.location.country);
+					index.continents = probes.map(probe => probe.location.continent);
+					index.regions = probes.map(probe => probe.location.region);
+					index.states = probes.map(probe => probe.location.state).filter(v => v);
+					index.tags = probes.map(probe => probe.tags.filter(tag => !tag.startsWith('u-'))).flat();
+
+					index.networks = probes.map(probe => probe.location.network).map((network) => {
+						return network.replace(networkNameCleanupPattern, '').trim();
+					}).filter(network => !network.includes(','));
+
+					Object.keys(index).forEach((key) => {
+						index[key] = uniqCountSortNormalize(index[key]);
+					});
+
+					index.cities = index.cities.map((cityRow) => {
+						let [ city, stateCode, countryCode ] = cityRow.value.split('\n');
+						let country = countries.find(c => c.code === countryCode).name || countryCode;
+						let stateName = states.find(s => s.code === stateCode)?.name || '';
+
+						return {
+							...cityRow,
+							value: `${city}+${stateName ? `US-${stateCode}` : countryCode}`,
+							normalizedValue: `${city}\n${stateName ? `${stateName}\nUS-${stateCode}\n${stateCode}\n` : ''}${country}\n${countryCode}`.toLowerCase(),
+							displayValue: `${city}`,
+							country: `${country} (${countryCode})`,
+							state: stateName ? `${stateName} (US-${stateCode})` : '',
+						};
+					});
+
+					index.countries = index.countries.map((country) => {
+						let value = countries.find(c => c.code === country.value).name || country.value;
+
+						return {
+							...country,
+							value,
+							normalizedValue: `${value}\n${country.normalizedValue}`.toLowerCase(),
+							countryCode: country.value,
+						};
+					}).map((country) => {
+						if (country.countryCode === 'GB') {
+							return {
+								...country,
+								normalizedValue: `${country.value}\nUK\nGreat Britain\nEngland`.toLowerCase(),
+							};
+						}
+
+						return country;
+					});
+
+					index.continents = index.continents.map((continent) => {
+						let value = continents.find(c => c.code === continent.value).name || continent.value;
+
+						return {
+							...continent,
+							value,
+							normalizedValue: `${value}\n${continent.value}`.toLowerCase(),
+						};
+					});
+
+					index.states = index.states.map((state) => {
+						let name = states.find(c => c.code === state.value).name || state.value;
+
+						return {
+							...state,
+							value: `US-${state.value}`,
+							displayValue: name,
+							normalizedValue: `${name}\nUS-${state.value}\n${state.value}\nUnited States\nUS`.toLowerCase(),
+							stateCode: `US-${state.value}`,
+						};
+					});
+
+					index.tags.unshift(...index.global);
+					index.tags[0].count = probes.length;
+				});
+			}
+		},
+	};
+</script>

--- a/src/views/pages/globalping/_index.html
+++ b/src/views/pages/globalping/_index.html
@@ -3,6 +3,7 @@
 <link rel="ractive" href="../../components/gp-footer.html" name="c-gp-footer">
 <link rel="ractive" href="../../components/notification.html" name="c-notification">
 <link rel="ractive" href="../../components/controlled-input.html" name="c-controlled-input">
+<link rel="ractive" href="../../components/location-input.html" name="c-location-input">
 <link rel="ractive" href="../../components/controlled-textarea.html" name="c-controlled-textarea">
 <link rel="ractive" href="../../components/tags-input.html" name="c-tags-input">
 <link rel="ractive" href="../../components/gp-results-controls.html" name="c-gp-results-controls">
@@ -144,8 +145,9 @@
 					</div>
 
 					<div class="gp_map-block_settings-wrapper_settings_grouped">
-						<c-controlled-input
-							id="locationInput"
+						<c-location-input
+							on-enter="@this.resetMapAndRunTest()"
+							rawProbes="{{rawProbes}}"
 							value="{{mainOptions.location}}"
 							error="{{inputErrors.location}}"
 							placeholder="Enter location"
@@ -159,7 +161,7 @@
 									height="14"
 									src="{{@shared.assetsHost}}/img/globalping/help-icon.svg">
 							{{/partial}}
-						</c-controlled-input>
+						</c-location-input>
 
 						<div class="gp_map-block_settings-wrapper_settings_subgroup">
 							<c-controlled-input
@@ -1403,6 +1405,7 @@
 		data () {
 			return {
 				_,
+				rawProbes: '',
 				PROBE_NO_TIMING_VALUE,
 				PROBE_STATUS_FAILED,
 				PROBE_STATUS_OFFLINE,
@@ -1839,7 +1842,6 @@
 			if (!Ractive.isServer) {
 				// run the test if user is pressed Enter inside of any of main options inputs
 				let targetInput = this.find('#targetInput');
-				let locationInput = this.find('#locationInput');
 				let limitInput = this.find('#limitInput');
 
 				let handleEnterBtn = (event) => {
@@ -1850,7 +1852,6 @@
 				};
 
 				targetInput.addEventListener('keypress', handleEnterBtn);
-				locationInput.addEventListener('keypress', handleEnterBtn);
 				limitInput.addEventListener('keypress', handleEnterBtn);
 			}
 		},
@@ -2442,6 +2443,8 @@
 					response = JSON.parse(response);
 				}
 
+				this.set('rawProbes', response);
+
 				let { totalCities, totalCountries } = response.reduce((res, item) => {
 					if (!res.citiesList.includes(item.location.city)) {
 						res.citiesList.push(item.location.city);
@@ -2849,9 +2852,12 @@
 					let splittedKeyName = key.split('.');
 					let splittedKeyNameLength = splittedKeyName.length;
 					let fieldName = splittedKeyName[splittedKeyNameLength - 1];
-					let errMsg = err.error.params[key].replace(/".*"/, fieldName);
 
-					res[fieldName] = errMsg;
+					if ([ 'locations', 'magic' ].includes(fieldName)) {
+						fieldName = 'location';
+					}
+
+					res[fieldName] = err.error.params[key].replace(/".*"/, fieldName);
 
 					if (splittedKeyName[0] === 'measurementOptions') {
 						measurementOptsErr = true;

--- a/src/views/pages/globalping/_index.html
+++ b/src/views/pages/globalping/_index.html
@@ -544,7 +544,7 @@
 				</c-gp-credits-message>
 			{{/if}}
 
-			<div class="gp_map-block_map-wrapper {{#unless showMap}}gp_map-block_map-wrapper_hidden{{/unless}}">
+			<div class="gp_map-block_map-wrapper {{#unless transitionMap}}transition-none{{/unless}} {{#unless showMap}}gp_map-block_map-wrapper_hidden{{/unless}}">
 				<div id="gp-map" class="gp_map-block_map-wrapper_map"></div>
 
 				{{#if testResults}}
@@ -592,6 +592,7 @@
 				<div class="gp_map-block_test-output">
 					<c-gp-results-controls
 						showMap="{{showMap}}"
+						originalShowMap="{{originalShowMap}}"
 						targets="{{targetsArr}}"
 						activeTargetIdx="{{activeTargetIdx}}"
 						rawOutputMode="{{rawOutputMode}}"
@@ -1417,6 +1418,8 @@
 					...INITIAL_MAIN_OPTS_VALUES,
 				},
 				showMap: true,
+				originalShowMap: true,
+				transitionMap: true,
 				infiniteSwitchEnabled: false,
 				showMeasurementOpts: false,
 				dnsTypesList: [ 'A', 'AAAA', 'ANY', 'CNAME', 'DNSKEY', 'DS', 'MX', 'NS', 'NSEC', 'PTR', 'RRSIG', 'SOA', 'TXT', 'SRV' ],
@@ -1836,6 +1839,17 @@
 						this.handleDropDownRunTestBtnNav();
 					}
 				});
+
+				this.observe('showMap', (newValue) => {
+					if (!newValue && this.get('originalShowMap')) {
+						this.set('transitionMap', false);
+					} else {
+						// using a deferred observer somehow isn't sufficient here
+						setTimeout(() => {
+							this.set('transitionMap', true);
+						}, 100);
+					}
+				});
 			}
 		},
 		oncomplete () {
@@ -2001,6 +2015,7 @@
 						this.set('rateCreditsData', combinedHeaders);
 						this.getTestMeasurementById({ measurementId: res.response.id });
 						this.getTestMeasurementById({ measurementId: res1.response.id, resNumber: 1 });
+						this.set('showMap', this.get('originalShowMap'));
 
 						// Update the URL without creating a new history entry.
 						app.router.replaceQueryParam('measurement', `${this.get('measurement')},${res1.response.id}`);
@@ -2009,6 +2024,7 @@
 					});
 				} else {
 					this.getTestMeasurementById({ measurementId: res.response.id });
+					this.set('showMap', this.get('originalShowMap'));
 				}
 			}).catch((err) => {
 				this.handlePostGPMeasError(err);
@@ -2780,6 +2796,7 @@
 				};
 
 				this.getTestMeasurementById({ measurementId: res.response.id, resNumber, isInfiniteMeas, reqParams: updReqParams });
+				this.set('showMap', this.get('originalShowMap'));
 			}).catch((err) => {
 				this.handlePostGPMeasError(err);
 			});
@@ -2845,6 +2862,7 @@
 					this.set('showCreditsError', true);
 				} else {
 					this.set('showCreditsData', false);
+					this.set('showMap', false);
 				}
 			} else if (err.error.type === 'validation_error') {
 				let measurementOptsErr = false;
@@ -2872,8 +2890,9 @@
 				if (measurementOptsErr) {
 					this.set('showMeasurementOpts', true);
 				}
-			} else if (err.error.type === 'no_probes_found') {
+			} else {
 				this.set('measurementErrMsg', err.error.message);
+				this.set('showMap', false);
 			}
 		},
 		reUseProbesRunTest () {

--- a/src/views/r-page-globalping.html
+++ b/src/views/r-page-globalping.html
@@ -95,6 +95,7 @@
 			<script src="https://cdn.jsdelivr.net/npm/jquery@3.6.3/dist/jquery.slim.min.js"></script>
 			<script src="https://cdn.jsdelivr.net/npm/bootstrap@3.3.7/dist/js/bootstrap.js"></script>
 			<script src="https://cdn.jsdelivr.net/npm/clipboard@2.0.11/dist/clipboard.min.js"></script>
+			<script src="https://cdn.jsdelivr.net/npm/@algolia/autocomplete-js@1.18.1/dist/umd/index.production.min.js"></script>
 			{{yield js}}
 			<script src="{{@shared.assetsHost}}/js/app-globalping.js?v={{@shared.assetsVersion}}"></script>
 			<script defer data-domain="globalping.io" src="https://datum.jsdelivr.com/js/script.js"></script>


### PR DESCRIPTION
Referencing US states and cities requires https://github.com/jsdelivr/globalping/issues/629, and doesn't work at the moment. Closes #537.

Also fixes displaying error messages for the location field and hides the map in case of errors that are shown below it, as those were easy to miss otherwise. 

TODO:
 - [x] If two values are present, autocomplete should not delete the first one.
 - [x] Improve `+` to work with networks and tags.
 - [x] Try to add a "no results" message.