### PR TITLE
Load Fonts From jsDelivr

### DIFF
--- a/src/views/pages/osscdn.html
+++ b/src/views/pages/osscdn.html
@@ -5,7 +5,10 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1">
 		<meta name="description" content="jsDelivr - A free, fast, and reliable Open Source CDN for npm and GitHub">
 		<title>OSSCDN.com is now jsDelivr</title>
-		<link rel="stylesheet" href="//fonts.googleapis.com/css?family=Open+Sans:200,400,600,700">
+		<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fontsource/open-sans@5.2.5/400.css">
+		<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fontsource/open-sans@5.2.5/600.css">
+		<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fontsource/open-sans@5.2.5/700.css">
+
 		<style>
 			body {
 				font-family: "Open Sans", Helvetica, Arial, sans-serif;

--- a/src/views/r-docs-globalping.html
+++ b/src/views/r-docs-globalping.html
@@ -53,16 +53,18 @@
 
 			<!-- Maybe will be useful in Firefox at some point. -->
 			<link rel="dns-prefetch" href="https://cdn.jsdelivr.net/">
-			<link rel="dns-prefetch" href="https://fonts.gstatic.com/">
 <!--			<link rel="dns-prefetch" href="https://datum.jsdelivr.com/">-->
 
 			<link rel="preconnect" href="https://cdn.jsdelivr.net/" crossorigin="anonymous">
-			<link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="anonymous">
 <!--			<link rel="preconnect" href="https://datum.jsdelivr.com/" crossorigin="anonymous">-->
-			<link rel="preconnect" href="https://fonts.googleapis.com" crossorigin="anonymous">
 
-			<link href="https://fonts.googleapis.com/css2?family=Lexend:wght@400;600;700&display=swap" rel="stylesheet">
-			<link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@500&display=swap" rel="stylesheet">
+
+			<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fontsource/lexend@5.2.5/400.css" media="print" onload="this.media='all'">
+			<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fontsource/lexend@5.2.5/600.css" media="print" onload="this.media='all'">
+			<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fontsource/lexend@5.2.5/700.css" media="print" onload="this.media='all'">
+
+			<link href="https://cdn.jsdelivr.net/npm/@fontsource/source-code-pro@5.2.5/500.css" rel="stylesheet">
+
 			<link rel="stylesheet" href="{{@shared.assetsHost}}/css/app.css?v={{@shared.assetsVersion}}">
 			<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/font-awesome@4.7.0/css/font-awesome.min.css" media="print" onload="this.media='all'">
 

--- a/src/views/r-docs.html
+++ b/src/views/r-docs.html
@@ -53,18 +53,20 @@
 
 			<!-- Maybe will be useful in Firefox at some point. -->
 			<link rel="dns-prefetch" href="https://cdn.jsdelivr.net/">
-			<link rel="dns-prefetch" href="https://fonts.gstatic.com/">
 			<link rel="dns-prefetch" href="https://data.jsdelivr.com/">
 			<link rel="dns-prefetch" href="https://datum.jsdelivr.com/">
 
 			<link rel="preconnect" href="https://cdn.jsdelivr.net/" crossorigin="anonymous">
-			<link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="anonymous">
 			<link rel="preconnect" href="https://data.jsdelivr.com/" crossorigin="anonymous">
 			<link rel="preconnect" href="https://datum.jsdelivr.com/" crossorigin="anonymous">
-			<link rel="preconnect" href="https://fonts.googleapis.com" crossorigin="anonymous">
 
-			<link href="https://fonts.googleapis.com/css2?family=Lexend:wght@400;600;700&display=swap" rel="stylesheet">
-			<link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@500&display=swap" rel="stylesheet">
+
+			<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fontsource/lexend@5.2.5/400.css" media="print" onload="this.media='all'">
+			<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fontsource/lexend@5.2.5/600.css" media="print" onload="this.media='all'">
+			<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fontsource/lexend@5.2.5/700.css" media="print" onload="this.media='all'">
+
+			<link href="https://cdn.jsdelivr.net/npm/@fontsource/source-code-pro@5.2.5/cyrillic-500.css" rel="stylesheet">
+
 			<link rel="stylesheet" href="{{@shared.assetsHost}}/css/app.css?v={{@shared.assetsVersion}}">
 			<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/font-awesome@4.7.0/css/font-awesome.min.css" media="print" onload="this.media='all'">
 

--- a/src/views/r-page-globalping.html
+++ b/src/views/r-page-globalping.html
@@ -63,19 +63,20 @@
 
 			<!-- Maybe will be useful in Firefox at some point. -->
 			<link rel="dns-prefetch" href="https://cdn.jsdelivr.net/">
-			<link rel="dns-prefetch" href="https://fonts.gstatic.com/">
 <!--			<link rel="dns-prefetch" href="https://datum.jsdelivr.com/">-->
 
 			<link rel="preconnect" href="https://cdn.jsdelivr.net/" crossorigin="anonymous">
-			<link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="anonymous">
 <!--			<link rel="preconnect" href="https://datum.jsdelivr.com/" crossorigin="anonymous">-->
-			<link rel="preconnect" href="https://fonts.googleapis.com" crossorigin="anonymous">
 
-			<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lexend:wght@400;500;600&display=swap" media="print" onload="this.media='all'">
-			<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@500&display=swap" media="print" onload="this.media='all'">
+			<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fontsource/lexend@5.2.5/400.css" media="print" onload="this.media='all'">
+			<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fontsource/lexend@5.2.5/500.css" media="print" onload="this.media='all'">
+			<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fontsource/lexend@5.2.5/600.css" media="print" onload="this.media='all'">
+
+			<link href="https://cdn.jsdelivr.net/npm/@fontsource/source-code-pro@5.2.5/500.css" rel="stylesheet" media="print" onload="this.media='all'">
+
 			<link rel="stylesheet" href="{{@shared.assetsHost}}/css/app.css?v={{@shared.assetsVersion}}">
 			<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/font-awesome@4.7.0/css/font-awesome.min.css" media="print" onload="this.media='all'">
-			<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter&display=swap" media="print" onload="this.media='all'">
+			<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fontsource/inter@5.2.5/400.css" media="print" onload="this.media='all'">
 
 			<link rel="sitemap" href="/sitemap/index.xml" type="application/xml">
 			{{yield css}}

--- a/src/views/r-page.html
+++ b/src/views/r-page.html
@@ -67,21 +67,22 @@
 
 			<!-- Maybe will be useful in Firefox at some point. -->
 			<link rel="dns-prefetch" href="https://cdn.jsdelivr.net/">
-			<link rel="dns-prefetch" href="https://fonts.gstatic.com/">
 			<link rel="dns-prefetch" href="https://data.jsdelivr.com/">
 			<link rel="dns-prefetch" href="https://datum.jsdelivr.com/">
 
 			<link rel="preconnect" href="https://cdn.jsdelivr.net/" crossorigin="anonymous">
-			<link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="anonymous">
 			<link rel="preconnect" href="https://data.jsdelivr.com/" crossorigin="anonymous">
 			<link rel="preconnect" href="https://datum.jsdelivr.com/" crossorigin="anonymous">
-			<link rel="preconnect" href="https://fonts.googleapis.com" crossorigin="anonymous">
 
-			<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lexend:wght@400;500;600&display=swap" media="print" onload="this.media='all'">
-			<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@500&display=swap" media="print" onload="this.media='all'">
+			<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fontsource/lexend@5.2.5/400.css" media="print" onload="this.media='all'">
+			<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fontsource/lexend@5.2.5/500.css" media="print" onload="this.media='all'">
+			<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fontsource/lexend@5.2.5/600.css" media="print" onload="this.media='all'">
+
+			<link href="https://cdn.jsdelivr.net/npm/@fontsource/source-code-pro@5.2.5/500.css" rel="stylesheet" media="print" onload="this.media='all'">
+
 			<link rel="stylesheet" href="{{@shared.assetsHost}}/css/app.css?v={{@shared.assetsVersion}}">
 			<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/font-awesome@4.7.0/css/font-awesome.min.css" media="print" onload="this.media='all'">
-			<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter&display=swap" media="print" onload="this.media='all'">
+			<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fontsource/inter@5.2.5/400.css" media="print" onload="this.media='all'">
 
 			<link rel="sitemap" href="/sitemap/index.xml" type="application/xml">
 			<link rel="search" href="/opensearch.xml" type="application/opensearchdescription+xml" title="jsDelivr">


### PR DESCRIPTION
Follows #732. Now all Google Fonts' references are replaced with jsDelivr.