### PR TITLE
Cleanup global events on unrender

### DIFF
--- a/src/assets/js/_.js
+++ b/src/assets/js/_.js
@@ -1559,4 +1559,7 @@ module.exports = {
 
 		return count === 1 ? singular : plural;
 	},
+	getScreenWidth (screenWidth) {
+		return screenWidth || window.innerWidth;
+	},
 };

--- a/src/assets/js/_.js
+++ b/src/assets/js/_.js
@@ -1559,7 +1559,4 @@ module.exports = {
 
 		return count === 1 ? singular : plural;
 	},
-	getScreenWidth (screenWidth) {
-		return screenWidth || window.innerWidth;
-	},
 };

--- a/src/assets/js/utils/listeners.js
+++ b/src/assets/js/utils/listeners.js
@@ -29,7 +29,7 @@ module.exports.stickySidebarScrollListener = (component) => {
 	let sidebar = document.querySelector('.page-content_side-menu');
 
 	if (sidebar) {
-		let top = sidebar.getBoundingClientRect().top + document.body.scrollTop;
+		let top = sidebar.getBoundingClientRect().top + (window.pageYOffset || document.documentElement.scrollTop);
 
 		let handleStickySidebarScroll = () => {
 			let y = document.scrollingElement.scrollTop;

--- a/src/assets/js/utils/listeners.js
+++ b/src/assets/js/utils/listeners.js
@@ -12,5 +12,26 @@ const addManagedListener = (component, target, event, handler) => {
 module.exports.addManagedListener = addManagedListener;
 
 module.exports.screenWidgetListener = (component) => {
-	addManagedListener(component, window, 'resize', debounce(throttle(() => this.set('screenWidth', window.innerWidth), 200)));
+	addManagedListener(component, window, 'resize', debounce(throttle(() => component.set('screenWidth', window.innerWidth), 200)));
+};
+
+module.exports.stickySidebarScrollListener = (component) => {
+	let sidebar = document.querySelector('.page-content_side-menu');
+
+	if (sidebar) {
+		let top = sidebar.getBoundingClientRect().top + document.body.scrollTop;
+
+		let handleStickySidebarScroll = () => {
+			let y = document.scrollingElement.scrollTop;
+			let currentSidebarTop = sidebar.getBoundingClientRect().top;
+
+			if ((currentSidebarTop <= 20 && currentSidebarTop >= 0) || y > top) {
+				sidebar.setAttribute('style', 'position: sticky; top: 20px');
+			} else {
+				sidebar.removeAttribute('style');
+			}
+		};
+
+		addManagedListener(component, window, 'scroll', handleStickySidebarScroll);
+	}
 };

--- a/src/assets/js/utils/listeners.js
+++ b/src/assets/js/utils/listeners.js
@@ -2,7 +2,17 @@ const debounce = require('./debounce');
 const throttle = require('./throttle');
 
 const addManagedListener = (component, target, event, handler) => {
+	if (!target || typeof target.addEventListener !== 'function' || typeof target.removeEventListener !== 'function') {
+		console.warn('Invalid target passed to addManagedListener');
+		return;
+	}
+
 	target.addEventListener(event, handler);
+
+	if (!component || typeof component.on !== 'function') {
+		console.warn('Invalid component passed to addManagedListener');
+		return;
+	}
 
 	component.on('unrender', () => {
 		target.removeEventListener(event, handler);
@@ -33,5 +43,6 @@ module.exports.stickySidebarScrollListener = (component) => {
 		};
 
 		addManagedListener(component, window, 'scroll', handleStickySidebarScroll);
+		handleStickySidebarScroll();
 	}
 };

--- a/src/assets/js/utils/listeners.js
+++ b/src/assets/js/utils/listeners.js
@@ -1,0 +1,16 @@
+const debounce = require('./debounce');
+const throttle = require('./throttle');
+
+const addManagedListener = (component, target, event, handler) => {
+	target.addEventListener(event, handler);
+
+	component.on('unrender', () => {
+		target.removeEventListener(event, handler);
+	});
+};
+
+module.exports.addManagedListener = addManagedListener;
+
+module.exports.screenWidgetListener = (component) => {
+	addManagedListener(component, window, 'resize', debounce(throttle(() => this.set('screenWidth', window.innerWidth), 200)));
+};

--- a/src/assets/js/utils/listeners.js
+++ b/src/assets/js/utils/listeners.js
@@ -21,7 +21,9 @@ const addManagedListener = (component, target, event, handler) => {
 
 module.exports.addManagedListener = addManagedListener;
 
-module.exports.screenWidgetListener = (component) => {
+module.exports.screenWidthListener = (component) => {
+	component.set('screenWidth', window.innerWidth);
+
 	addManagedListener(component, window, 'resize', debounce(throttle(() => component.set('screenWidth', window.innerWidth), 200)));
 };
 

--- a/src/views/components/controlled-input.html
+++ b/src/views/components/controlled-input.html
@@ -29,7 +29,6 @@
 </div>
 
 <script>
-	const _ = require('../../assets/js/_');
 	const listeners = require('../../assets/js/utils/listeners');
 	const tooltip = require('../../assets/js/decorators/tooltip');
 
@@ -59,7 +58,7 @@
 				});
 
 				this.observe('screenWidth', (screenWidth) => {
-					if (_.getScreenWidth(screenWidth) < 768) {
+					if ((screenWidth || window.innerWidth) < 768) {
 						this.set('errMsgTopPos', true);
 					} else {
 						this.set('errMsgTopPos', false);

--- a/src/views/components/controlled-input.html
+++ b/src/views/components/controlled-input.html
@@ -29,6 +29,7 @@
 </div>
 
 <script>
+	const _ = require('../../assets/js/_');
 	const listeners = require('../../assets/js/utils/listeners');
 	const tooltip = require('../../assets/js/decorators/tooltip');
 
@@ -58,7 +59,7 @@
 				});
 
 				this.observe('screenWidth', (screenWidth) => {
-					if ((screenWidth || window.innerWidth) < 768) {
+					if (_.getScreenWidth(screenWidth) < 768) {
 						this.set('errMsgTopPos', true);
 					} else {
 						this.set('errMsgTopPos', false);

--- a/src/views/components/controlled-input.html
+++ b/src/views/components/controlled-input.html
@@ -69,7 +69,10 @@
 		},
 		onrender () {
 			// detect window resize
-			window.addEventListener('resize', debounce(throttle(() => this.set('screenWidth', innerWidth), 200)));
+			let handleResize = debounce(throttle(() => this.set('screenWidth', innerWidth), 200));
+			window.addEventListener('resize', handleResize);
+
+			this.on('unrender', () => window.removeEventListener('resize', handleResize));
 		},
 	};
 </script>

--- a/src/views/components/controlled-input.html
+++ b/src/views/components/controlled-input.html
@@ -29,8 +29,7 @@
 </div>
 
 <script>
-	const debounce = require('../../assets/js/utils/debounce');
-	const throttle = require('../../assets/js/utils/throttle');
+	const listeners = require('../../assets/js/utils/listeners');
 	const tooltip = require('../../assets/js/decorators/tooltip');
 
 	component.exports = {
@@ -59,7 +58,7 @@
 				});
 
 				this.observe('screenWidth', (screenWidth) => {
-					if ((screenWidth || innerWidth) < 768) {
+					if ((screenWidth || window.innerWidth) < 768) {
 						this.set('errMsgTopPos', true);
 					} else {
 						this.set('errMsgTopPos', false);
@@ -68,11 +67,7 @@
 			}
 		},
 		onrender () {
-			// detect window resize
-			let handleResize = debounce(throttle(() => this.set('screenWidth', innerWidth), 200));
-			window.addEventListener('resize', handleResize);
-
-			this.on('unrender', () => window.removeEventListener('resize', handleResize));
+			listeners.screenWidthListener(this);
 		},
 	};
 </script>

--- a/src/views/components/controlled-textarea.html
+++ b/src/views/components/controlled-textarea.html
@@ -30,8 +30,7 @@
 </label>
 
 <script>
-	const debounce = require('../../assets/js/utils/debounce');
-	const throttle = require('../../assets/js/utils/throttle');
+	const listeners = require('../../assets/js/utils/listeners');
 	const DEFAULT_TEXTAREA_ROWS_AMOUNT = 2;
 
 	component.exports = {
@@ -59,7 +58,7 @@
 				});
 
 				this.observe('screenWidth', (screenWidth) => {
-					if ((screenWidth || innerWidth) < 768) {
+					if ((screenWidth || window.innerWidth) < 768) {
 						this.set('errMsgTopPos', true);
 					} else {
 						this.set('errMsgTopPos', false);
@@ -119,11 +118,7 @@
 			}
 		},
 		onrender () {
-			// detect window resize
-			let handleResize = debounce(throttle(() => this.set('screenWidth', innerWidth), 200));
-			window.addEventListener('resize', handleResize);
-
-			this.on('unrender', () => window.removeEventListener('resize', handleResize));
+			listeners.screenWidthListener(this);
 		},
 	};
 </script>

--- a/src/views/components/controlled-textarea.html
+++ b/src/views/components/controlled-textarea.html
@@ -120,7 +120,10 @@
 		},
 		onrender () {
 			// detect window resize
-			window.addEventListener('resize', debounce(throttle(() => this.set('screenWidth', innerWidth), 200)));
+			let handleResize = debounce(throttle(() => this.set('screenWidth', innerWidth), 200));
+			window.addEventListener('resize', handleResize);
+
+			this.on('unrender', () => window.removeEventListener('resize', handleResize));
 		},
 	};
 </script>

--- a/src/views/components/controlled-textarea.html
+++ b/src/views/components/controlled-textarea.html
@@ -30,7 +30,6 @@
 </label>
 
 <script>
-	const _ = require('../../assets/js/_');
 	const listeners = require('../../assets/js/utils/listeners');
 	const DEFAULT_TEXTAREA_ROWS_AMOUNT = 2;
 
@@ -59,7 +58,7 @@
 				});
 
 				this.observe('screenWidth', (screenWidth) => {
-					if (_.getScreenWidth(screenWidth) < 768) {
+					if ((screenWidth || window.innerWidth) < 768) {
 						this.set('errMsgTopPos', true);
 					} else {
 						this.set('errMsgTopPos', false);

--- a/src/views/components/controlled-textarea.html
+++ b/src/views/components/controlled-textarea.html
@@ -30,6 +30,7 @@
 </label>
 
 <script>
+	const _ = require('../../assets/js/_');
 	const listeners = require('../../assets/js/utils/listeners');
 	const DEFAULT_TEXTAREA_ROWS_AMOUNT = 2;
 
@@ -58,7 +59,7 @@
 				});
 
 				this.observe('screenWidth', (screenWidth) => {
-					if ((screenWidth || window.innerWidth) < 768) {
+					if (_.getScreenWidth(screenWidth) < 768) {
 						this.set('errMsgTopPos', true);
 					} else {
 						this.set('errMsgTopPos', false);

--- a/src/views/components/location-input.html
+++ b/src/views/components/location-input.html
@@ -31,8 +31,7 @@
 
 <script>
 	const _ = require('../../assets/js/_');
-	const debounce = require('../../assets/js/utils/debounce');
-	const throttle = require('../../assets/js/utils/throttle');
+	const listeners = require('../../assets/js/utils/listeners');
 	const tooltip = require('../../assets/js/decorators/tooltip');
 
 	const states = require('../../assets/json/usa-states.json');
@@ -73,7 +72,7 @@
 				});
 
 				this.observe('screenWidth', (screenWidth) => {
-					if ((screenWidth || innerWidth) < 768) {
+					if ((screenWidth || window.innerWidth) < 768) {
 						this.set('errMsgTopPos', true);
 					} else {
 						this.set('errMsgTopPos', false);
@@ -82,11 +81,7 @@
 			}
 		},
 		onrender () {
-			// detect window resize
-			let handleResize = debounce(throttle(() => this.set('screenWidth', innerWidth), 200));
-			window.addEventListener('resize', handleResize);
-
-			this.on('unrender', () => window.removeEventListener('resize', handleResize));
+			listeners.screenWidthListener(this);
 
 			if (!Ractive.isServer) {
 				let normalizedProbes;

--- a/src/views/components/location-input.html
+++ b/src/views/components/location-input.html
@@ -72,7 +72,7 @@
 				});
 
 				this.observe('screenWidth', (screenWidth) => {
-					if (_.getScreenWidth(screenWidth) < 768) {
+					if ((screenWidth || window.innerWidth) < 768) {
 						this.set('errMsgTopPos', true);
 					} else {
 						this.set('errMsgTopPos', false);

--- a/src/views/components/location-input.html
+++ b/src/views/components/location-input.html
@@ -83,7 +83,10 @@
 		},
 		onrender () {
 			// detect window resize
-			window.addEventListener('resize', debounce(throttle(() => this.set('screenWidth', innerWidth), 200)));
+			let handleResize = debounce(throttle(() => this.set('screenWidth', innerWidth), 200));
+			window.addEventListener('resize', handleResize);
+
+			this.on('unrender', () => window.removeEventListener('resize', handleResize));
 
 			if (!Ractive.isServer) {
 				let normalizedProbes;

--- a/src/views/components/location-input.html
+++ b/src/views/components/location-input.html
@@ -72,7 +72,7 @@
 				});
 
 				this.observe('screenWidth', (screenWidth) => {
-					if ((screenWidth || window.innerWidth) < 768) {
+					if (_.getScreenWidth(screenWidth) < 768) {
 						this.set('errMsgTopPos', true);
 					} else {
 						this.set('errMsgTopPos', false);

--- a/src/views/components/network-request-chart.html
+++ b/src/views/components/network-request-chart.html
@@ -163,7 +163,7 @@
 					let chartPeriodType = this.get('period').periodType;
 					let showChartBandwidth = this.get('showChartBandwidth');
 					let showProviderBreakdown = this.get('showProviderBreakdown');
-					let screenWidth = _.getScreenWidth(this.get('screenWidth'));
+					let screenWidth = this.get('screenWidth') ? this.get('screenWidth') : window.innerWidth;
 					let usageChartGroupBy = 'day';
 					let hitsProviders = [ ...rawHitsChartData.hits.providers ];
 					let bandwidthProviders = [ ...rawHitsChartData.bandwidth.providers ];

--- a/src/views/components/network-request-chart.html
+++ b/src/views/components/network-request-chart.html
@@ -343,7 +343,10 @@
 			});
 
 			// detect window resize
-			window.addEventListener('resize', debounce(throttle(() => this.set('screenWidth', innerWidth), 200)));
+			let handleResize = debounce(throttle(() => this.set('screenWidth', innerWidth), 200));
+			window.addEventListener('resize', handleResize);
+
+			this.on('unrender', () => window.removeEventListener('resize', handleResize));
 		},
 		combineProvidersData (providersList) {
 			return providersList.reduce((res, currProvider) => {

--- a/src/views/components/network-request-chart.html
+++ b/src/views/components/network-request-chart.html
@@ -163,7 +163,7 @@
 					let chartPeriodType = this.get('period').periodType;
 					let showChartBandwidth = this.get('showChartBandwidth');
 					let showProviderBreakdown = this.get('showProviderBreakdown');
-					let screenWidth = this.get('screenWidth') ? this.get('screenWidth') : window.innerWidth;
+					let screenWidth = _.getScreenWidth(this.get('screenWidth'));
 					let usageChartGroupBy = 'day';
 					let hitsProviders = [ ...rawHitsChartData.hits.providers ];
 					let bandwidthProviders = [ ...rawHitsChartData.bandwidth.providers ];

--- a/src/views/components/network-request-chart.html
+++ b/src/views/components/network-request-chart.html
@@ -78,8 +78,7 @@
 	const http = require('../../assets/js/utils/http');
 	const initCharts = require('../../assets/js/utils/charts');
 	const providersJson = require('../../assets/json/net-providers.json');
-	const debounce = require('../../assets/js/utils/debounce');
-	const throttle = require('../../assets/js/utils/throttle');
+	const listeners = require('../../assets/js/utils/listeners');
 
 	component.exports = {
 		data () {
@@ -164,7 +163,7 @@
 					let chartPeriodType = this.get('period').periodType;
 					let showChartBandwidth = this.get('showChartBandwidth');
 					let showProviderBreakdown = this.get('showProviderBreakdown');
-					let screenWidth = this.get('screenWidth') ? this.get('screenWidth') : innerWidth;
+					let screenWidth = this.get('screenWidth') ? this.get('screenWidth') : window.innerWidth;
 					let usageChartGroupBy = 'day';
 					let hitsProviders = [ ...rawHitsChartData.hits.providers ];
 					let bandwidthProviders = [ ...rawHitsChartData.bandwidth.providers ];
@@ -342,11 +341,7 @@
 				});
 			});
 
-			// detect window resize
-			let handleResize = debounce(throttle(() => this.set('screenWidth', innerWidth), 200));
-			window.addEventListener('resize', handleResize);
-
-			this.on('unrender', () => window.removeEventListener('resize', handleResize));
+			listeners.screenWidthListener(this);
 		},
 		combineProvidersData (providersList) {
 			return providersList.reduce((res, currProvider) => {

--- a/src/views/components/network-request-map.html
+++ b/src/views/components/network-request-map.html
@@ -386,7 +386,10 @@
 					});
 
 					// detect window resize
-					window.addEventListener('resize', debounce(throttle(() => this.set('screenWidth', innerWidth), 200)));
+					let handleResize = debounce(throttle(() => this.set('screenWidth', innerWidth), 200));
+					window.addEventListener('resize', handleResize);
+
+					this.on('unrender', () => window.removeEventListener('resize', handleResize));
 				});
 			}
 		},

--- a/src/views/components/network-request-map.html
+++ b/src/views/components/network-request-map.html
@@ -290,7 +290,7 @@
 					// draw the Map and the Legend
 					this.observe('preparedMapData screenWidth', () => {
 						let legendColorRange = [ '#a2ecf6', '#65d69e', '#90eb9d', '#ffff8c', '#f9d057', '#f29e2e', '#e76818', '#d7191c' ];
-						let screenWidth = _.getScreenWidth(this.get('screenWidth'));
+						let screenWidth = this.get('screenWidth') ? this.get('screenWidth') : window.innerWidth;
 						let svg = d3.select('#hits-map');
 
 						if (!svg || !this.get('__ready') || !screenWidth || !this.get('preparedMapData')) { return; }

--- a/src/views/components/network-request-map.html
+++ b/src/views/components/network-request-map.html
@@ -290,7 +290,7 @@
 					// draw the Map and the Legend
 					this.observe('preparedMapData screenWidth', () => {
 						let legendColorRange = [ '#a2ecf6', '#65d69e', '#90eb9d', '#ffff8c', '#f9d057', '#f29e2e', '#e76818', '#d7191c' ];
-						let screenWidth = this.get('screenWidth') ? this.get('screenWidth') : window.innerWidth;
+						let screenWidth = _.getScreenWidth(this.get('screenWidth'));
 						let svg = d3.select('#hits-map');
 
 						if (!svg || !this.get('__ready') || !screenWidth || !this.get('preparedMapData')) { return; }

--- a/src/views/components/network-request-map.html
+++ b/src/views/components/network-request-map.html
@@ -116,8 +116,7 @@
 	const _ = require('../../assets/js/_');
 	const http = require('../../assets/js/utils/http');
 	const providersJson = require('../../assets/json/net-providers.json');
-	const debounce = require('../../assets/js/utils/debounce');
-	const throttle = require('../../assets/js/utils/throttle');
+	const listeners = require('../../assets/js/utils/listeners');
 	const LEGEND_AXIS_TICKS_AMOUNT = 8;
 
 	component.exports = {
@@ -291,7 +290,7 @@
 					// draw the Map and the Legend
 					this.observe('preparedMapData screenWidth', () => {
 						let legendColorRange = [ '#a2ecf6', '#65d69e', '#90eb9d', '#ffff8c', '#f9d057', '#f29e2e', '#e76818', '#d7191c' ];
-						let screenWidth = this.get('screenWidth') ? this.get('screenWidth') : innerWidth;
+						let screenWidth = this.get('screenWidth') ? this.get('screenWidth') : window.innerWidth;
 						let svg = d3.select('#hits-map');
 
 						if (!svg || !this.get('__ready') || !screenWidth || !this.get('preparedMapData')) { return; }
@@ -385,11 +384,7 @@
 						svg.call(zoom).call(zoom.transform, d3.zoomIdentity);
 					});
 
-					// detect window resize
-					let handleResize = debounce(throttle(() => this.set('screenWidth', innerWidth), 200));
-					window.addEventListener('resize', handleResize);
-
-					this.on('unrender', () => window.removeEventListener('resize', handleResize));
+					listeners.screenWidthListener(this);
 				});
 			}
 		},

--- a/src/views/components/package-stats.html
+++ b/src/views/components/package-stats.html
@@ -382,7 +382,7 @@
 
 					let chartPeriodType = this.get('periodData').periodType;
 					let usageChartGroupBy = this.get('usageChartGroupBy');
-					let screenWidth = _.getScreenWidth(this.get('screenWidth'));
+					let screenWidth = this.get('screenWidth') ? this.get('screenWidth') : window.innerWidth;
 					let dataType = showChartBandwidth ? 'bandwidth' : 'hits';
 
 					// collect X-Axis dates, group data by period, get
@@ -430,7 +430,7 @@
 
 					let chartPeriodType = this.get('periodData').periodType;
 					let usageChartGroupBy = this.get('usageChartGroupBy');
-					let screenWidth = _.getScreenWidth(this.get('screenWidth'));
+					let screenWidth = this.get('screenWidth') ? this.get('screenWidth') : window.innerWidth;
 
 					// collect versions for hitsChart Legend element
 					let hitsChartLegendVersions = rawHitsChartData.map(item => ({ version: item.version }));

--- a/src/views/components/package-stats.html
+++ b/src/views/components/package-stats.html
@@ -731,7 +731,10 @@
 				});
 
 				// detect window resize
-				window.addEventListener('resize', debounce(throttle(() => this.set('screenWidth', innerWidth), 200)));
+				let handleResize = debounce(throttle(() => this.set('screenWidth', innerWidth), 200));
+				window.addEventListener('resize', handleResize);
+
+				this.on('unrender', () => window.removeEventListener('resize', handleResize));
 			}
 		},
 

--- a/src/views/components/package-stats.html
+++ b/src/views/components/package-stats.html
@@ -382,7 +382,7 @@
 
 					let chartPeriodType = this.get('periodData').periodType;
 					let usageChartGroupBy = this.get('usageChartGroupBy');
-					let screenWidth = this.get('screenWidth') ? this.get('screenWidth') : window.innerWidth;
+					let screenWidth = _.getScreenWidth(this.get('screenWidth'));
 					let dataType = showChartBandwidth ? 'bandwidth' : 'hits';
 
 					// collect X-Axis dates, group data by period, get
@@ -430,7 +430,7 @@
 
 					let chartPeriodType = this.get('periodData').periodType;
 					let usageChartGroupBy = this.get('usageChartGroupBy');
-					let screenWidth = this.get('screenWidth') ? this.get('screenWidth') : window.innerWidth;
+					let screenWidth = _.getScreenWidth(this.get('screenWidth'));
 
 					// collect versions for hitsChart Legend element
 					let hitsChartLegendVersions = rawHitsChartData.map(item => ({ version: item.version }));

--- a/src/views/components/package-stats.html
+++ b/src/views/components/package-stats.html
@@ -175,8 +175,7 @@
 	const _ = require('../../assets/js/_');
 	const http = require('../../assets/js/utils/http');
 	const stats = require('../../assets/js/utils/stats');
-	const debounce = require('../../assets/js/utils/debounce');
-	const throttle = require('../../assets/js/utils/throttle');
+	const listeners = require('../../assets/js/utils/listeners');
 	const initCharts = require('../../assets/js/utils/charts');
 	const DEFAULT_LIMIT = 5;
 	const COLORS_ARR = [
@@ -383,7 +382,7 @@
 
 					let chartPeriodType = this.get('periodData').periodType;
 					let usageChartGroupBy = this.get('usageChartGroupBy');
-					let screenWidth = this.get('screenWidth') ? this.get('screenWidth') : innerWidth;
+					let screenWidth = this.get('screenWidth') ? this.get('screenWidth') : window.innerWidth;
 					let dataType = showChartBandwidth ? 'bandwidth' : 'hits';
 
 					// collect X-Axis dates, group data by period, get
@@ -431,7 +430,7 @@
 
 					let chartPeriodType = this.get('periodData').periodType;
 					let usageChartGroupBy = this.get('usageChartGroupBy');
-					let screenWidth = this.get('screenWidth') ? this.get('screenWidth') : innerWidth;
+					let screenWidth = this.get('screenWidth') ? this.get('screenWidth') : window.innerWidth;
 
 					// collect versions for hitsChart Legend element
 					let hitsChartLegendVersions = rawHitsChartData.map(item => ({ version: item.version }));
@@ -730,11 +729,7 @@
 					});
 				});
 
-				// detect window resize
-				let handleResize = debounce(throttle(() => this.set('screenWidth', innerWidth), 200));
-				window.addEventListener('resize', handleResize);
-
-				this.on('unrender', () => window.removeEventListener('resize', handleResize));
+				listeners.screenWidthListener(this);
 			}
 		},
 

--- a/src/views/components/package.html
+++ b/src/views/components/package.html
@@ -172,10 +172,8 @@
 				// change Nav Menu titles depending on the screen size (also on the resize of the page)
 				// switch tab to readme after resizing (if it was Files tab)
 				this.observe('screenWidth', (newScreenWidth) => {
-					let actualScreenWidth = newScreenWidth ? newScreenWidth : window.innerWidth;
-
 					// set tab titles after resizing
-					if (actualScreenWidth < 1200) {
+					if (_.getScreenWidth(newScreenWidth) < 1200) {
 						this.set('navMenuTitles', NAV_MENU_SHORT_TITLES);
 					} else {
 						this.set('navMenuTitles', NAV_MENU_FULL_TITLES);

--- a/src/views/components/package.html
+++ b/src/views/components/package.html
@@ -172,7 +172,7 @@
 				// change Nav Menu titles depending on the screen size (also on the resize of the page)
 				// switch tab to readme after resizing (if it was Files tab)
 				this.observe('screenWidth', (newScreenWidth) => {
-					let actualScreenWidth = newScreenWidth ? newScreenWidth : innerWidth;
+					let actualScreenWidth = newScreenWidth ? newScreenWidth : window.innerWidth;
 
 					// set tab titles after resizing
 					if (actualScreenWidth < 1200) {

--- a/src/views/components/package.html
+++ b/src/views/components/package.html
@@ -172,8 +172,10 @@
 				// change Nav Menu titles depending on the screen size (also on the resize of the page)
 				// switch tab to readme after resizing (if it was Files tab)
 				this.observe('screenWidth', (newScreenWidth) => {
+					let actualScreenWidth = newScreenWidth ? newScreenWidth : window.innerWidth;
+
 					// set tab titles after resizing
-					if (_.getScreenWidth(newScreenWidth) < 1200) {
+					if (actualScreenWidth < 1200) {
 						this.set('navMenuTitles', NAV_MENU_SHORT_TITLES);
 					} else {
 						this.set('navMenuTitles', NAV_MENU_FULL_TITLES);

--- a/src/views/components/periods-dropdown.html
+++ b/src/views/components/periods-dropdown.html
@@ -46,6 +46,7 @@
 
 <script>
 	const _ = require('../../assets/js/_');
+	const listeners = require('../../assets/js/utils/listeners');
 
 	component.exports = {
 		computed: {
@@ -116,8 +117,7 @@
 					}
 				};
 
-				document.addEventListener('click', handleOnOutsideClick);
-				this.on('unrender', () => document.removeEventListener('click', handleOnOutsideClick));
+				listeners.addManagedListener(this, document, 'click', handleOnOutsideClick);
 
 				this.observe('dropdownOpened', (newValue) => {
 					let ul = this.find('.dropdown_body_list');

--- a/src/views/components/periods-dropdown.html
+++ b/src/views/components/periods-dropdown.html
@@ -108,13 +108,16 @@
 				// close dropdown and clear filter on click outside the dropdown el
 				let el = this.find('.c-periods-dropdown');
 
-				document.addEventListener('click', (event) => {
+				let handleOnOutsideClick = (event) => {
 					let currDropdownOpened = this.get('dropdownOpened');
 
 					if (currDropdownOpened && !el.contains(event.target)) {
 						this.set('dropdownOpened', false);
 					}
-				});
+				};
+
+				document.addEventListener('click', handleOnOutsideClick);
+				this.on('unrender', () => document.removeEventListener('click', handleOnOutsideClick));
 
 				this.observe('dropdownOpened', (newValue) => {
 					let ul = this.find('.dropdown_body_list');

--- a/src/views/components/range-slider.html
+++ b/src/views/components/range-slider.html
@@ -26,6 +26,7 @@
 	const _ = require('../../assets/js/_');
 	const debounce = require('../../assets/js/utils/debounce');
 	const throttle = require('../../assets/js/utils/throttle');
+	const listeners = require('../../assets/js/utils/listeners');
 	const CUSTOM_DONATION_VALUE = 'custom';
 	const NO_DONATION = {
 		value: 'free',
@@ -199,8 +200,7 @@
 					this.updateSliderPosition();
 				};
 
-				document.addEventListener('keydown', handleSliderKeyboardNavigation);
-				this.on('unrender', () => document.removeEventListener('keydown', handleSliderKeyboardNavigation));
+				listeners.addManagedListener(this, document, 'keydown', handleSliderKeyboardNavigation);
 
 				// initiate the slider
 				this.updateSliderPosition();
@@ -256,8 +256,7 @@
 					this.createSliderLabels();
 				}, 200));
 
-				window.addEventListener('resize', handleSliderResize);
-				this.on('unrender', () => window.removeEventListener('resize', handleSliderResize));
+				listeners.addManagedListener(this, document, 'resize', handleSliderResize);
 			}
 		},
 		updateSliderPosition () {

--- a/src/views/components/range-slider.html
+++ b/src/views/components/range-slider.html
@@ -183,7 +183,7 @@
 				});
 
 				// handle keyboard controls
-				document.addEventListener('keydown', (event) => {
+				let handleSliderKeyboardNavigation = (event) => {
 					let sliderPosition = this.get('sliderPosition');
 
 					if (event.key === 'ArrowLeft') {
@@ -197,7 +197,10 @@
 					this.set('sliderPosition', sliderPosition);
 
 					this.updateSliderPosition();
-				});
+				};
+
+				document.addEventListener('keydown', handleSliderKeyboardNavigation);
+				this.on('unrender', () => document.removeEventListener('keydown', handleSliderKeyboardNavigation));
 
 				// initiate the slider
 				this.updateSliderPosition();
@@ -240,7 +243,7 @@
 				});
 
 				// detect window resize and update partWidth and slider knob posision
-				window.addEventListener('resize', debounce(throttle(() => {
+				let handleSliderResize = debounce(throttle(() => {
 					let partsGap = this.get('partsGap');
 					let sliderPosition = this.get('sliderPosition');
 					let updPartWidth = this.get('partsElements')[0].offsetWidth + partsGap;
@@ -251,7 +254,10 @@
 					this.set('partWidth', updPartWidth);
 					this.set('screenWidth', window.innerWidth);
 					this.createSliderLabels();
-				}, 200)));
+				}, 200));
+
+				window.addEventListener('resize', handleSliderResize);
+				this.on('unrender', () => window.removeEventListener('resize', handleSliderResize));
 			}
 		},
 		updateSliderPosition () {

--- a/src/views/components/tags-input.html
+++ b/src/views/components/tags-input.html
@@ -175,7 +175,10 @@
 		},
 		onrender () {
 			// detect window resize
-			window.addEventListener('resize', debounce(throttle(() => this.set('screenWidth', innerWidth), 200)));
+			let handleResize = debounce(throttle(() => this.set('screenWidth', innerWidth), 200));
+			window.addEventListener('resize', handleResize);
+
+			this.on('unrender', () => window.removeEventListener('resize', handleResize));
 		},
 		oncomplete () {
 			if (!Ractive.isServer) {
@@ -261,11 +264,14 @@
 					this.handleInputFocus(tagsBlockEl);
 				});
 
-				document.addEventListener('click', (e) => {
+				let handleOnClickOutside = (e) => {
 					if (e.target.isConnected && !tagsBlockEl.contains(e.target)) {
 						tagsBlockEl.classList.remove('focused');
 					}
-				});
+				};
+
+				document.addEventListener('click', handleOnClickOutside);
+				this.on('unrender', () => document.removeEventListener('click', handleOnClickOutside));
 
 				this.observe('isDisabled', (isDisabled) => {
 					if (isDisabled) {

--- a/src/views/components/tags-input.html
+++ b/src/views/components/tags-input.html
@@ -265,8 +265,7 @@
 					}
 				};
 
-				document.addEventListener('click', handleOnClickOutside);
-				this.on('unrender', () => document.removeEventListener('click', handleOnClickOutside));
+				listeners.addManagedListener(this, document, 'click', handleOnClickOutside);
 
 				this.observe('isDisabled', (isDisabled) => {
 					if (isDisabled) {

--- a/src/views/components/tags-input.html
+++ b/src/views/components/tags-input.html
@@ -73,8 +73,7 @@
 
 <script>
 	const ipRegex = require('../../assets/js/utils/ip-regex');
-	const debounce = require('../../assets/js/utils/debounce');
-	const throttle = require('../../assets/js/utils/throttle');
+	const listeners = require('../../assets/js/utils/listeners');
 	const tooltip = require('../../assets/js/decorators/tooltip');
 	const IP_V4_VALUE = 4;
 	const IP_V6_VALUE = 6;
@@ -126,7 +125,7 @@
 				});
 
 				this.observe('screenWidth', (screenWidth) => {
-					if ((screenWidth || innerWidth) < 768) {
+					if ((screenWidth || window.innerWidth) < 768) {
 						this.set('errMsgTopPos', true);
 					} else {
 						this.set('errMsgTopPos', false);
@@ -174,11 +173,7 @@
 			}
 		},
 		onrender () {
-			// detect window resize
-			let handleResize = debounce(throttle(() => this.set('screenWidth', innerWidth), 200));
-			window.addEventListener('resize', handleResize);
-
-			this.on('unrender', () => window.removeEventListener('resize', handleResize));
+			listeners.screenWidthListener(this);
 		},
 		oncomplete () {
 			if (!Ractive.isServer) {

--- a/src/views/components/tags-input.html
+++ b/src/views/components/tags-input.html
@@ -72,7 +72,6 @@
 </div>
 
 <script>
-	const _ = require('../../assets/js/_');
 	const ipRegex = require('../../assets/js/utils/ip-regex');
 	const listeners = require('../../assets/js/utils/listeners');
 	const tooltip = require('../../assets/js/decorators/tooltip');
@@ -126,7 +125,7 @@
 				});
 
 				this.observe('screenWidth', (screenWidth) => {
-					if (_.getScreenWidth(screenWidth) < 768) {
+					if ((screenWidth || window.innerWidth) < 768) {
 						this.set('errMsgTopPos', true);
 					} else {
 						this.set('errMsgTopPos', false);

--- a/src/views/components/tags-input.html
+++ b/src/views/components/tags-input.html
@@ -72,6 +72,7 @@
 </div>
 
 <script>
+	const _ = require('../../assets/js/_');
 	const ipRegex = require('../../assets/js/utils/ip-regex');
 	const listeners = require('../../assets/js/utils/listeners');
 	const tooltip = require('../../assets/js/decorators/tooltip');
@@ -125,7 +126,7 @@
 				});
 
 				this.observe('screenWidth', (screenWidth) => {
-					if ((screenWidth || window.innerWidth) < 768) {
+					if (_.getScreenWidth(screenWidth) < 768) {
 						this.set('errMsgTopPos', true);
 					} else {
 						this.set('errMsgTopPos', false);

--- a/src/views/components/top-stats-table.html
+++ b/src/views/components/top-stats-table.html
@@ -104,7 +104,7 @@
 			preliminaryHeight () {
 				let pageLimit = this.get('pageLimit');
 
-				if (innerWidth < 1272) {
+				if (window.innerWidth < 1272) {
 					return pageLimit * 72;
 				}
 

--- a/src/views/components/version-dropdown.html
+++ b/src/views/components/version-dropdown.html
@@ -37,6 +37,8 @@
 </div>
 
 <script>
+	const listeners = require('../../assets/js/utils/listeners');
+
 	component.exports = {
 		computed: {
 			filteredVersions () {
@@ -92,8 +94,7 @@
 					}
 				};
 
-				document.addEventListener('click', handleOnClickOutside);
-				this.on('unrender', () => document.removeEventListener('click', handleOnClickOutside));
+				listeners.addManagedListener(this, document, 'click', handleOnClickOutside);
 
 				this.observe('dropdownOpened', (newValue) => {
 					let ul = this.find('.version-dropdown_wrapper_list');

--- a/src/views/components/version-dropdown.html
+++ b/src/views/components/version-dropdown.html
@@ -84,13 +84,16 @@
 				// close dropdown and clear filter on click outside the dropdown el
 				let el = this.find('.version-dropdown');
 
-				document.addEventListener('click', (event) => {
+				let handleOnClickOutside = (event) => {
 					let currDropdownOpened = this.get('dropdownOpened');
 
 					if (currDropdownOpened && !el.contains(event.target)) {
 						this.set('dropdownOpened', false);
 					}
-				});
+				};
+
+				document.addEventListener('click', handleOnClickOutside);
+				this.on('unrender', () => document.removeEventListener('click', handleOnClickOutside));
 
 				this.observe('dropdownOpened', (newValue) => {
 					let ul = this.find('.version-dropdown_wrapper_list');

--- a/src/views/pages/_oss-cdn-project.html
+++ b/src/views/pages/_oss-cdn-project.html
@@ -455,7 +455,10 @@
 			});
 
 			// detect window resize
-			window.addEventListener('resize', debounce(throttle(() => this.set('screenWidth', innerWidth), 200)));
+			let handleResize = debounce(throttle(() => this.set('screenWidth', innerWidth), 200));
+			window.addEventListener('resize', handleResize);
+
+			this.on('unrender', () => window.removeEventListener('resize', handleResize));
 		},
 		handlePeriodSelecting () {
 			return (periodData) => {

--- a/src/views/pages/_oss-cdn-project.html
+++ b/src/views/pages/_oss-cdn-project.html
@@ -149,8 +149,7 @@
 	const http = require('../../assets/js/utils/http');
 	const stats = require('../../assets/js/utils/stats');
 	const initCharts = require('../../assets/js/utils/charts');
-	const debounce = require('../../assets/js/utils/debounce');
-	const throttle = require('../../assets/js/utils/throttle');
+	const listeners = require('../../assets/js/utils/listeners');
 
 	component.exports = {
 		computed: {
@@ -310,7 +309,7 @@
 					let chartPeriodType = this.get('periodData').periodType;
 					let showChartBandwidth = this.get('showChartBandwidth');
 					let usageChartGroupBy = this.get('usageChartGroupBy');
-					let screenWidth = this.get('screenWidth') ? this.get('screenWidth') : innerWidth;
+					let screenWidth = this.get('screenWidth') ? this.get('screenWidth') : window.innerWidth;
 					let dataType = showChartBandwidth ? 'bandwidth' : 'hits';
 
 					// collect X-Axis dates, group data by period, get
@@ -454,11 +453,7 @@
 				});
 			});
 
-			// detect window resize
-			let handleResize = debounce(throttle(() => this.set('screenWidth', innerWidth), 200));
-			window.addEventListener('resize', handleResize);
-
-			this.on('unrender', () => window.removeEventListener('resize', handleResize));
+			listeners.screenWidthListener(this);
 		},
 		handlePeriodSelecting () {
 			return (periodData) => {

--- a/src/views/pages/become-a-sponsor.html
+++ b/src/views/pages/become-a-sponsor.html
@@ -396,7 +396,7 @@
 		onrender () {
 			if (!Ractive.isServer) {
 				// init slider only when screen width is larger than 768px
-				if (innerWidth < 768) {
+				if (window.innerWidth < 768) {
 					let plansListWrapper = document.querySelector('.plans_wrapper');
 					let plansList = document.querySelector('.plans_wrapper_plans-list');
 					let tabsWrapper = document.querySelector('.plans_tabs');

--- a/src/views/pages/docs/data.jsdelivr.com.html
+++ b/src/views/pages/docs/data.jsdelivr.com.html
@@ -58,7 +58,11 @@
 		onrender () {
 			if (!Ractive.isServer) {
 				this.set('screenWidth', innerWidth);
-				window.addEventListener('resize', debounce(() => this.set('screenWidth', innerWidth), 100));
+
+				let handleResize = debounce(() => this.set('screenWidth', innerWidth), 100);
+				window.addEventListener('resize', handleResize);
+
+				this.on('unrender', () => window.removeEventListener('resize', handleResize));
 
 				this.find('rapi-doc').addEventListener('before-render', () => {
 					this.set('loaded', true);

--- a/src/views/pages/docs/data.jsdelivr.com.html
+++ b/src/views/pages/docs/data.jsdelivr.com.html
@@ -42,7 +42,7 @@
 </r-docs>
 
 <script>
-	const debounce = require('../../../assets/js/utils/debounce');
+	const listeners = require('../../../assets/js/utils/listeners');
 
 	component.exports = {
 		data () {
@@ -59,10 +59,7 @@
 			if (!Ractive.isServer) {
 				this.set('screenWidth', innerWidth);
 
-				let handleResize = debounce(() => this.set('screenWidth', innerWidth), 100);
-				window.addEventListener('resize', handleResize);
-
-				this.on('unrender', () => window.removeEventListener('resize', handleResize));
+				listeners.screenWidthListener(this);
 
 				this.find('rapi-doc').addEventListener('before-render', () => {
 					this.set('loaded', true);

--- a/src/views/pages/documentation.html
+++ b/src/views/pages/documentation.html
@@ -102,6 +102,7 @@
 
 <script>
 	const _ = require('../../assets/js/_');
+	const listeners = require('../../assets/js/utils/listeners');
 	const ID_PREFIX = 'id-';
 
 	component.exports = {
@@ -235,8 +236,7 @@
 								prevPageY = currentPageY;
 							};
 
-							window.addEventListener('scroll', handleScroll);
-							this.on('unrender', () => window.removeEventListener('scroll', handleScroll));
+							listeners.addManagedListener(this, window, 'scroll', handleScroll);
 						});
 					}).catch(() => {
 						this.set('readmeText', `Failed to load the document. Please view it directly at:<br>https://raw.githubusercontent.com/jsdelivr/jsdelivr/master/README.md`);
@@ -246,26 +246,7 @@
 		},
 		onrender () {
 			if (!Ractive.isServer) {
-				// handle sticky side menu
-				let sidebar = document.querySelector('.page-content_side-menu');
-
-				if (sidebar) {
-					let top = sidebar.getBoundingClientRect().top + document.body.scrollTop;
-
-					let handleStickySidebarScroll = () => {
-						let y = document.scrollingElement.scrollTop;
-						let currentSidebarTop = sidebar.getBoundingClientRect().top;
-
-						if ((currentSidebarTop <= 20 && currentSidebarTop >= 0) || y > top) {
-							sidebar.setAttribute('style', 'position: sticky; top: 20px');
-						} else {
-							sidebar.removeAttribute('style');
-						}
-					};
-
-					window.addEventListener('scroll', handleStickySidebarScroll);
-					this.on('unrender', () => window.removeEventListener('scroll', handleStickySidebarScroll));
-				}
+				listeners.stickySidebarScrollListener(this);
 			}
 		},
 	};

--- a/src/views/pages/documentation.html
+++ b/src/views/pages/documentation.html
@@ -210,7 +210,7 @@
 							let prevPageY = 0;
 							let currentPageY = 0;
 
-							window.addEventListener('scroll', () => {
+							let handleScroll = () => {
 								currentPageY = window.pageYOffset;
 
 								if (prevPageY > currentPageY) {
@@ -233,7 +233,10 @@
 								});
 
 								prevPageY = currentPageY;
-							});
+							};
+
+							window.addEventListener('scroll', handleScroll);
+							this.on('unrender', () => window.removeEventListener('scroll', handleScroll));
 						});
 					}).catch(() => {
 						this.set('readmeText', `Failed to load the document. Please view it directly at:<br>https://raw.githubusercontent.com/jsdelivr/jsdelivr/master/README.md`);
@@ -249,7 +252,7 @@
 				if (sidebar) {
 					let top = sidebar.getBoundingClientRect().top + document.body.scrollTop;
 
-					window.addEventListener('scroll', () => {
+					let handleStickySidebarScroll = () => {
 						let y = document.scrollingElement.scrollTop;
 						let currentSidebarTop = sidebar.getBoundingClientRect().top;
 
@@ -258,7 +261,10 @@
 						} else {
 							sidebar.removeAttribute('style');
 						}
-					});
+					};
+
+					window.addEventListener('scroll', handleStickySidebarScroll);
+					this.on('unrender', () => window.removeEventListener('scroll', handleStickySidebarScroll));
 				}
 			}
 		},

--- a/src/views/pages/foundationcdn.html
+++ b/src/views/pages/foundationcdn.html
@@ -264,6 +264,7 @@
 
 <script>
 	const http = require('../../assets/js/utils/http');
+	const listeners = require('../../assets/js/utils/listeners');
 	const { buildLinks } = require('../../assets/js/utils/build-links');
 	const clipboard = require('../../assets/js/decorators/clipboard');
 
@@ -407,8 +408,7 @@
 					}
 				};
 
-				document.addEventListener('scroll', handleScroll);
-				this.on('unrender', () => document.removeEventListener('scroll', handleScroll));
+				listeners.addManagedListener(this, window, 'scroll', handleScroll);
 			}
 		},
 		getLink (files, addTag, enableSri, outFiles) {

--- a/src/views/pages/foundationcdn.html
+++ b/src/views/pages/foundationcdn.html
@@ -380,7 +380,7 @@
 					console.error(`Package versions not found.`, error);
 				});
 
-				document.addEventListener('scroll', () => {
+				let handleScroll = () => {
 					let $customizeBar = document.querySelector('.section-2 .customize-bar');
 					let sectionOneEl = document.querySelector('.section-1');
 
@@ -405,7 +405,10 @@
 						$customizeBar.classList.remove('fixed-cb');
 						document.querySelector('.section-2').style.marginTop = 0;
 					}
-				});
+				};
+
+				document.addEventListener('scroll', handleScroll);
+				this.on('unrender', () => document.removeEventListener('scroll', handleScroll));
 			}
 		},
 		getLink (files, addTag, enableSri, outFiles) {

--- a/src/views/pages/globalping/_index.html
+++ b/src/views/pages/globalping/_index.html
@@ -1230,8 +1230,7 @@
 <script>
 	const _ = require('../../../assets/js/_.js');
 	const ipRegex = require('../../../assets/js/utils/ip-regex');
-	const debounce = require('../../../assets/js/utils/debounce');
-	const throttle = require('../../../assets/js/utils/throttle');
+	const listeners = require('../../../assets/js/utils/listeners');
 	const clipboard = require('../../../assets/js/decorators/clipboard');
 	const http = require('../../../assets/js/utils/http');
 	const has = require('../../../assets/js/utils/has');
@@ -1475,11 +1474,7 @@
 					this.initMap();
 				}
 
-				// detect window resize
-				let handleResize = debounce(throttle(() => this.set('screenWidth', innerWidth), 200));
-				window.addEventListener('resize', handleResize);
-
-				this.on('unrender', () => window.removeEventListener('resize', handleResize));
+				listeners.screenWidthListener(this);
 			}
 		},
 		oninit () {
@@ -1793,7 +1788,7 @@
 				// set initial screenWidth value
 				this.observe('screenWidth', (screenWidth) => {
 					if (!screenWidth) {
-						this.set('screenWidth', innerWidth);
+						this.set('screenWidth', window.innerWidth);
 					}
 				});
 

--- a/src/views/pages/globalping/_index.html
+++ b/src/views/pages/globalping/_index.html
@@ -1476,7 +1476,10 @@
 				}
 
 				// detect window resize
-				window.addEventListener('resize', debounce(throttle(() => this.set('screenWidth', innerWidth), 200)));
+				let handleResize = debounce(throttle(() => this.set('screenWidth', innerWidth), 200));
+				window.addEventListener('resize', handleResize);
+
+				this.on('unrender', () => window.removeEventListener('resize', handleResize));
 			}
 		},
 		oninit () {

--- a/src/views/pages/globalping/_users.html
+++ b/src/views/pages/globalping/_users.html
@@ -130,6 +130,7 @@
 	const _ = require('../../../assets/js/_');
 	const debounce = require('../../../assets/js/utils/debounce');
 	const throttle = require('../../../assets/js/utils/throttle');
+	const listeners = require('../../../assets/js/utils/listeners');
 	const http = require('../../../assets/js/utils/http');
 	const dataCache = require('../../../assets/js/utils/data-cache');
 	const tooltip = require('../../../assets/js/decorators/tooltip');
@@ -188,8 +189,7 @@
 		onrender () {
 			if (!Ractive.isServer) {
 				let handleResize = debounce(throttle(() => this.calculateMaxTagCount(), 200));
-				window.addEventListener('resize', handleResize);
-				this.on('unrender', () => window.removeEventListener('resize', handleResize));
+				listeners.addManagedListener(this, window, 'resize', handleResize);
 
 				this.observe('userProbes', () => this.calculateMaxTagCount(), { defer: true });
 			}

--- a/src/views/pages/globalping/_users.html
+++ b/src/views/pages/globalping/_users.html
@@ -187,7 +187,10 @@
 		},
 		onrender () {
 			if (!Ractive.isServer) {
-				window.addEventListener('resize', debounce(throttle(() => this.calculateMaxTagCount(), 200)));
+				let handleResize = debounce(throttle(() => this.calculateMaxTagCount(), 200));
+				window.addEventListener('resize', handleResize);
+				this.on('unrender', () => window.removeEventListener('resize', handleResize));
+
 				this.observe('userProbes', () => this.calculateMaxTagCount(), { defer: true });
 			}
 		},

--- a/src/views/pages/globalping/docs/api.globalping.io.html
+++ b/src/views/pages/globalping/docs/api.globalping.io.html
@@ -59,7 +59,11 @@
 		onrender () {
 			if (!Ractive.isServer) {
 				this.set('screenWidth', innerWidth);
-				window.addEventListener('resize', debounce(() => this.set('screenWidth', innerWidth), 100));
+
+				let handleResize = debounce(() => this.set('screenWidth', innerWidth), 100);
+				window.addEventListener('resize', handleResize);
+
+				this.on('unrender', () => window.removeEventListener('resize', handleResize));
 
 				this.find('rapi-doc').addEventListener('before-render', () => {
 					this.set('loaded', true);

--- a/src/views/pages/globalping/docs/api.globalping.io.html
+++ b/src/views/pages/globalping/docs/api.globalping.io.html
@@ -42,7 +42,7 @@
 </r-docs>
 
 <script>
-	const debounce = require('../../../../assets/js/utils/debounce');
+	const listeners = require('../../../../assets/js/utils/listeners');
 
 	component.exports = {
 		data () {
@@ -58,12 +58,9 @@
 		},
 		onrender () {
 			if (!Ractive.isServer) {
-				this.set('screenWidth', innerWidth);
+				this.set('screenWidth', window.innerWidth);
 
-				let handleResize = debounce(() => this.set('screenWidth', innerWidth), 100);
-				window.addEventListener('resize', handleResize);
-
-				this.on('unrender', () => window.removeEventListener('resize', handleResize));
+				listeners.screenWidthListener(this);
 
 				this.find('rapi-doc').addEventListener('before-render', () => {
 					this.set('loaded', true);

--- a/src/views/pages/globalping/docs/auth.globalping.io.html
+++ b/src/views/pages/globalping/docs/auth.globalping.io.html
@@ -59,7 +59,11 @@
 		onrender () {
 			if (!Ractive.isServer) {
 				this.set('screenWidth', innerWidth);
-				window.addEventListener('resize', debounce(() => this.set('screenWidth', innerWidth), 100));
+
+				let handleResize = debounce(() => this.set('screenWidth', innerWidth), 100);
+				window.addEventListener('resize', handleResize);
+
+				this.on('unrender', () => window.removeEventListener('resize', handleResize));
 
 				this.find('rapi-doc').addEventListener('before-render', () => {
 					this.set('loaded', true);

--- a/src/views/pages/globalping/docs/auth.globalping.io.html
+++ b/src/views/pages/globalping/docs/auth.globalping.io.html
@@ -42,7 +42,7 @@
 </r-docs>
 
 <script>
-	const debounce = require('../../../../assets/js/utils/debounce');
+	const listeners = require('../../../../assets/js/utils/listeners');
 
 	component.exports = {
 		data () {
@@ -58,12 +58,9 @@
 		},
 		onrender () {
 			if (!Ractive.isServer) {
-				this.set('screenWidth', innerWidth);
+				this.set('screenWidth', window.innerWidth);
 
-				let handleResize = debounce(() => this.set('screenWidth', innerWidth), 100);
-				window.addEventListener('resize', handleResize);
-
-				this.on('unrender', () => window.removeEventListener('resize', handleResize));
+				listeners.screenWidthListener(this);
 
 				this.find('rapi-doc').addEventListener('before-render', () => {
 					this.set('loaded', true);

--- a/src/views/pages/globalping/network.html
+++ b/src/views/pages/globalping/network.html
@@ -242,7 +242,10 @@
 				this.set('@shared.googleMapsLoaded', true);
 
 				// detect window resize
-				window.addEventListener('resize', debounce(throttle(() => this.set('screenWidth', innerWidth), 200)));
+				let handleResize = debounce(throttle(() => this.set('screenWidth', innerWidth), 200));
+				window.addEventListener('resize', handleResize);
+
+				this.on('unrender', () => window.removeEventListener('resize', handleResize));
 			}
 		},
 		handleProbesByCoordsChange () {

--- a/src/views/pages/globalping/network.html
+++ b/src/views/pages/globalping/network.html
@@ -89,8 +89,7 @@
 </r-page>
 
 <script>
-	const debounce = require('../../../assets/js/utils/debounce');
-	const throttle = require('../../../assets/js/utils/throttle');
+	const listeners = require('../../../assets/js/utils/listeners');
 	const has = require('../../../assets/js/utils/has');
 	const http = require('../../../assets/js/utils/http');
 	const CONTINENTS = require('../../../assets/json/continents.json');
@@ -190,7 +189,7 @@
 				// set initial screenWidth value
 				this.observe('screenWidth', (screenWidth) => {
 					if (!screenWidth) {
-						this.set('screenWidth', innerWidth);
+						this.set('screenWidth', window.innerWidth);
 					} else {
 						let columnsAmount = this.getLayoutColumnsAmount(screenWidth);
 						let filteredProbes = this.get('filteredProbes');
@@ -241,11 +240,7 @@
 			if (!Ractive.isServer) {
 				this.set('@shared.googleMapsLoaded', true);
 
-				// detect window resize
-				let handleResize = debounce(throttle(() => this.set('screenWidth', innerWidth), 200));
-				window.addEventListener('resize', handleResize);
-
-				this.on('unrender', () => window.removeEventListener('resize', handleResize));
+				listeners.screenWidthListener(this);
 			}
 		},
 		handleProbesByCoordsChange () {

--- a/src/views/pages/globalping/terms.html
+++ b/src/views/pages/globalping/terms.html
@@ -112,7 +112,7 @@
 				if (sidebar) {
 					let top = sidebar.getBoundingClientRect().top + document.body.scrollTop;
 
-					window.addEventListener('scroll', () => {
+					let handleStickySidebarScroll = () => {
 						let y = document.scrollingElement.scrollTop;
 						let currentSidebarTop = sidebar.getBoundingClientRect().top;
 
@@ -121,7 +121,10 @@
 						} else {
 							sidebar.removeAttribute('style');
 						}
-					});
+					};
+
+					window.addEventListener('scroll', handleStickySidebarScroll);
+					this.on('unrender', () => window.removeEventListener('scroll', handleStickySidebarScroll));
 				}
 			}
 		},

--- a/src/views/pages/globalping/terms.html
+++ b/src/views/pages/globalping/terms.html
@@ -96,6 +96,8 @@
 </r-page>
 
 <script>
+	const listeners = require('../../../assets/js/utils/listeners');
+
 	component.exports = {
 		data () {
 			return {
@@ -106,26 +108,7 @@
 		},
 		onrender () {
 			if (!Ractive.isServer) {
-				// handle sticky side menu
-				let sidebar = document.querySelector('.page-content_side-menu');
-
-				if (sidebar) {
-					let top = sidebar.getBoundingClientRect().top + document.body.scrollTop;
-
-					let handleStickySidebarScroll = () => {
-						let y = document.scrollingElement.scrollTop;
-						let currentSidebarTop = sidebar.getBoundingClientRect().top;
-
-						if ((currentSidebarTop <= 20 && currentSidebarTop >= 0) || y > top) {
-							sidebar.setAttribute('style', 'position: sticky; top: 20px');
-						} else {
-							sidebar.removeAttribute('style');
-						}
-					};
-
-					window.addEventListener('scroll', handleStickySidebarScroll);
-					this.on('unrender', () => window.removeEventListener('scroll', handleStickySidebarScroll));
-				}
+				listeners.stickySidebarScrollListener(this);
 			}
 		},
 	};

--- a/src/views/pages/statistics.html
+++ b/src/views/pages/statistics.html
@@ -195,8 +195,7 @@
 	const tooltip = require('../../assets/js/decorators/tooltip');
 	const countries = require('../../assets/json/countries.json');
 	const continents = require('../../assets/json/continents.json');
-	const debounce = require('../../assets/js/utils/debounce');
-	const throttle = require('../../assets/js/utils/throttle');
+	const listeners = require('../../assets/js/utils/listeners');
 	const GLOBAL_SEARCH_ITEM_TYPE = 'global';
 	const NO_RESULTS_SEARCH_ITEM_TYPE = 'no-results';
 	const COUNTRY_SEARCH_ITEM_TYPE = 'country';
@@ -235,7 +234,7 @@
 			this.set('countriesList', countriesList);
 
 			this.observe('screenWidth', (screenWidth) => {
-				if ((screenWidth || innerWidth) < 768) {
+				if ((screenWidth || window.innerWidth) < 768) {
 					this.set('searchPlaceholder', 'Search');
 				} else {
 					this.set('searchPlaceholder', 'Filter for a specific country or a continent...');
@@ -392,11 +391,7 @@
 				}, 4);
 			});
 
-			// detect window resize
-			let handleResize = debounce(throttle(() => this.set('screenWidth', innerWidth), 200));
-			window.addEventListener('resize', handleResize);
-
-			this.on('unrender', () => window.removeEventListener('resize', handleResize));
+			listeners.screenWidthListener(this);
 		},
 		oncomplete () {
 			let globalEl = this.find('.global-data');

--- a/src/views/pages/statistics.html
+++ b/src/views/pages/statistics.html
@@ -234,7 +234,7 @@
 			this.set('countriesList', countriesList);
 
 			this.observe('screenWidth', (screenWidth) => {
-				if ((screenWidth || window.innerWidth) < 768) {
+				if (_.getScreenWidth(screenWidth) < 768) {
 					this.set('searchPlaceholder', 'Search');
 				} else {
 					this.set('searchPlaceholder', 'Filter for a specific country or a continent...');

--- a/src/views/pages/statistics.html
+++ b/src/views/pages/statistics.html
@@ -234,7 +234,7 @@
 			this.set('countriesList', countriesList);
 
 			this.observe('screenWidth', (screenWidth) => {
-				if (_.getScreenWidth(screenWidth) < 768) {
+				if ((screenWidth || window.innerWidth) < 768) {
 					this.set('searchPlaceholder', 'Search');
 				} else {
 					this.set('searchPlaceholder', 'Filter for a specific country or a continent...');

--- a/src/views/pages/statistics.html
+++ b/src/views/pages/statistics.html
@@ -393,7 +393,10 @@
 			});
 
 			// detect window resize
-			window.addEventListener('resize', debounce(throttle(() => this.set('screenWidth', innerWidth), 200)));
+			let handleResize = debounce(throttle(() => this.set('screenWidth', innerWidth), 200));
+			window.addEventListener('resize', handleResize);
+
+			this.on('unrender', () => window.removeEventListener('resize', handleResize));
 		},
 		oncomplete () {
 			let globalEl = this.find('.global-data');

--- a/src/views/pages/terms.html
+++ b/src/views/pages/terms.html
@@ -120,7 +120,7 @@
 				if (sidebar) {
 					let top = sidebar.getBoundingClientRect().top + document.body.scrollTop;
 
-					window.addEventListener('scroll', () => {
+					let handleStickySidebarScroll = () => {
 						let y = document.scrollingElement.scrollTop;
 						let currentSidebarTop = sidebar.getBoundingClientRect().top;
 
@@ -129,7 +129,10 @@
 						} else {
 							sidebar.removeAttribute('style');
 						}
-					});
+					};
+
+					window.addEventListener('scroll', handleStickySidebarScroll);
+					this.on('unrender', () => window.removeEventListener('scroll', handleStickySidebarScroll));
 				}
 			}
 		},

--- a/src/views/pages/terms.html
+++ b/src/views/pages/terms.html
@@ -105,6 +105,8 @@
 </r-page>
 
 <script>
+	const listeners = require('../../assets/js/utils/listeners');
+
 	component.exports = {
 		data () {
 			return {
@@ -114,26 +116,7 @@
 		},
 		onrender () {
 			if (!Ractive.isServer) {
-				// handle sticky side menu
-				let sidebar = document.querySelector('.page-content_side-menu');
-
-				if (sidebar) {
-					let top = sidebar.getBoundingClientRect().top + document.body.scrollTop;
-
-					let handleStickySidebarScroll = () => {
-						let y = document.scrollingElement.scrollTop;
-						let currentSidebarTop = sidebar.getBoundingClientRect().top;
-
-						if ((currentSidebarTop <= 20 && currentSidebarTop >= 0) || y > top) {
-							sidebar.setAttribute('style', 'position: sticky; top: 20px');
-						} else {
-							sidebar.removeAttribute('style');
-						}
-					};
-
-					window.addEventListener('scroll', handleStickySidebarScroll);
-					this.on('unrender', () => window.removeEventListener('scroll', handleStickySidebarScroll));
-				}
+				listeners.stickySidebarScrollListener(this);
 			}
 		},
 	};


### PR DESCRIPTION
Closes #736

I believe this is working properly. I'm not completely sure what is the difference between oninit, onrender and oncomplete, I assume they run one after the other. Anyways the unrender calls should be attached properly and in my tests everything was working properly but I suggest a thorough testing maybe I've missed something as its a big pr.

@MartinKolarik :

- Also as a sidenote, I think resize and sticky sidebar handlers should be moved to a util asset since its being duplicated a lot.
- Another sidenote, I could not figure out where `innerWidth` variable is being supplied. It is working but I have no idea where it's coming from.