### PR TITLE
Make package file section more accessible

### DIFF
--- a/src/assets/less/components/copy-dropdown.less
+++ b/src/assets/less/components/copy-dropdown.less
@@ -2,9 +2,23 @@
 	margin-right: 24px;
 	cursor: pointer;
 
-	> span {
+	> button {
+		all: unset;
 		display: flex;
 		align-items: center;
 		justify-content: center;
+
+		&:focus {
+			outline: auto;
+		}
+	}
+
+	li > button {
+		all: unset;
+		box-sizing: border-box;
+
+		&:focus {
+			outline: auto;
+		}
 	}
 }

--- a/src/assets/less/components/package-file-browser.less
+++ b/src/assets/less/components/package-file-browser.less
@@ -9,6 +9,19 @@
 	.box-files {
 		width: 100%;
 
+		.disable-button-styles {
+			all: unset;
+			color: #79849a;
+			overflow: hidden;
+			text-overflow: ellipsis;
+			white-space: nowrap;
+			cursor: pointer;
+
+			&:focus {
+				outline: auto;
+			}
+		}
+
 		.box-sub-header {
 			min-width: 700px;
 			border-bottom: @c-gray 1px solid;
@@ -20,15 +33,25 @@
 			color: #111a2c;
 		}
 
-		.path-text, .path-active-part, .path-divider {
-			font-size: 18px;
-			line-height: 26px;
-		}
-
 		.path-text {
+			all: unset;
 			font-weight: 600;
 			letter-spacing: .2px;
 			color: #111a2c;
+			cursor: pointer;
+
+			&:focus {
+				outline: auto;
+			}
+
+			&:hover {
+				text-decoration: underline;
+			}
+		}
+
+		.path-text, .path-active-part, .path-divider {
+			font-size: 18px;
+			line-height: 26px;
 		}
 
 		.path-active-part, .path-divider, .path-divider-small {
@@ -38,6 +61,16 @@
 		.show-more-toggle {
 			text-align: center;
 			margin-top: 10px;
+
+			button {
+				color: #ff5627;
+				text-decoration: none;
+
+				&:hover {
+					color: #ff5627;
+					text-decoration: underline;
+				}
+			}
 		}
 	}
 
@@ -118,7 +151,7 @@
 		height: 40px;
 		margin-bottom: 8px;
 
-		> a {
+		> button {
 			display: flex;
 			color: #111a2c;
 			text-decoration: none;
@@ -155,11 +188,15 @@
 			column-gap: 24px;
 		}
 
-		> a {
+		> button, & > a {
 			color: #79849a;
 			overflow: hidden;
 			text-overflow: ellipsis;
 			white-space: nowrap;
+
+			&:hover {
+				text-decoration: underline;
+			}
 		}
 
 		label {

--- a/src/assets/less/components/package.less
+++ b/src/assets/less/components/package.less
@@ -648,7 +648,7 @@
 					max-width: 320px;
 
 					li {
-						> a {
+						> a, > button {
 							display: flex;
 							align-items: center;
 							height: 40px;

--- a/src/views/components/copy-dropdown.html
+++ b/src/views/components/copy-dropdown.html
@@ -60,10 +60,6 @@
 						items.eq(nextIndex).focus();
 					}
 				});
-
-				setTimeout(() => {
-					dropdown.find('.dropdown-menu li:first-child button').focus();
-				}, 10);
 			};
 
 			let handleDropdownHidden = (event) => {

--- a/src/views/components/copy-dropdown.html
+++ b/src/views/components/copy-dropdown.html
@@ -1,25 +1,25 @@
 <div class="c-copy-dropdown btn-group {{#if dropup}}dropup{{/if}}">
-	<span data-toggle="dropdown">
+	<button data-toggle="dropdown" role="button" aria-haspopup="true">
 		<img width="20" height="20" src="{{@shared.assetsHost}}/img/icons/copy-btn-black.svg" loading="lazy"/>
-	</span>
+	</button>
 
-	<ul class="dropdown-menu dropdown-menu-right">
+	<ul class="dropdown-menu dropdown-menu-right" role="listbox" aria-label="Copy options" aria-expanded="false">
 		<li>
-			<a as-clipboard="undefined, dropup ? 'bottom' : 'top', '.c-copy-dropdown'" data-clipboard-text="{{url}}">Copy URL</a>
+			<button as-clipboard="undefined, dropup ? 'bottom' : 'top', '.c-copy-dropdown'" data-clipboard-text="{{url}}">Copy URL</button>
 		</li>
 		{{#if hash}}
 			<li>
-				<a as-clipboard="undefined, dropup ? 'bottom' : 'top', '.c-copy-dropdown'" data-clipboard-text="{{buildIntegrity(hash)}}">Copy SRI</a>
+				<button as-clipboard="undefined, dropup ? 'bottom' : 'top', '.c-copy-dropdown'" data-clipboard-text="{{buildIntegrity(hash)}}">Copy SRI</button>
 			</li>
 		{{/if}}
 
 		{{#if canBuildHtml(url)}}
 			<li>
-				<a as-clipboard="undefined, dropup ? 'bottom' : 'top', '.c-copy-dropdown'" data-clipboard-text="{{buildHtml(url)}}">Copy HTML</a>
+				<button as-clipboard="undefined, dropup ? 'bottom' : 'top', '.c-copy-dropdown'" data-clipboard-text="{{buildHtml(url)}}">Copy HTML</button>
 			</li>
 			{{#if hash}}
 				<li>
-					<a as-clipboard="undefined, dropup ? 'bottom' : 'top', '.c-copy-dropdown'" data-clipboard-text="{{buildHtml(url, hash)}}">Copy HTML + SRI</a>
+					<button as-clipboard="undefined, dropup ? 'bottom' : 'top', '.c-copy-dropdown'" data-clipboard-text="{{buildHtml(url, hash)}}">Copy HTML + SRI</button>
 				</li>
 			{{/if}}
 		{{/if}}
@@ -40,6 +40,45 @@
 				buildHtml,
 				canBuildHtml,
 			};
+		},
+		onrender () {
+			let handleDropdownShown = (event) => {
+				let dropdown = $(event.target);
+				dropdown.find('.dropdown-menu').attr('aria-expanded', true);
+
+				dropdown.on('keydown', (e) => {
+					if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+						e.preventDefault();
+						let items = dropdown.find('.dropdown-menu li button');
+						let currentIndex = items.index(e.target);
+						let nextIndex = (currentIndex + (e.key === 'ArrowDown' ? 1 : -1)) % items.length;
+
+						if (nextIndex < 0) {
+							nextIndex = items.length - 1;
+						}
+
+						items.eq(nextIndex).focus();
+					}
+				});
+
+				setTimeout(() => {
+					dropdown.find('.dropdown-menu li:first-child button').focus();
+				}, 10);
+			};
+
+			let handleDropdownHidden = (event) => {
+				let dropdown = $(event.target);
+				dropdown.find('.dropdown-menu').attr('aria-expanded', false);
+				dropdown.find('.dropdown-toggle').focus();
+			};
+
+			$(document).on('shown.bs.dropdown', handleDropdownShown);
+			$(document).on('hidden.bs.dropdown', handleDropdownHidden);
+
+			this.on('unrender', () => {
+				$(document).off('shown.bs.dropdown', handleDropdownShown);
+				$(document).off('hidden.bs.dropdown', handleDropdownHidden);
+			});
 		},
 	};
 </script>

--- a/src/views/components/package-file-browser.html
+++ b/src/views/components/package-file-browser.html
@@ -5,10 +5,10 @@
 	<div class="box-files">
 		<div class="path-n-version">
 			<div>
-				<a on-click="@this.set('path', [])" class="path-text">{{name}}</a>
+				<button on-click="@this.set('path', [])" class="path-text">{{name}}</button>
 				{{#each path.slice(0, -1)}}
 					<span class="path-divider">{{' / '}}</span>
-					<a on-click="@this.splice('path', @index + 1)" class="path-text">{{this}}</a>
+					<button on-click="@this.splice('path', @index + 1)" class="path-text">{{this}}</button>
 				{{/each}}
 				{{#if path}}
 					<span class="path-divider">{{' / '}}</span>
@@ -58,7 +58,13 @@
 							checked="{{@this.getCollectionIndex(~/collection, ~/type, ~/name, ~/sharedVersion, ~/default) !== -1}}"
 							twoway="false">
 
-						<label for="df" on-click="@this.toggleCollectionFile(~/default)" as-tooltip="'Add to collection'"></label>
+						<label for="df"
+							on-click="@this.toggleCollectionFile(~/default)"
+							on-keydown="@this.handleLabelKeydown(event, ~/default)"
+							as-tooltip="'Add to collection'"
+							role="button"
+							aria-pressed="{{@this.getCollectionIndex(~/collection, ~/type, ~/name, ~/sharedVersion, ~/default) !== -1}}"
+							tabindex="0"></label>
 					</div>
 				</div>
 			{{/if}}
@@ -73,11 +79,11 @@
 
 					{{#if path.length}}
 						<div class="files-list-back">
-							<a on-click="@this.pop('path')">
+							<button class="disable-button-styles" on-click="@this.pop('path')" tabindex="0">
 								<img width="20" height="20" src="{{@shared.assetsHost}}/img/icons/back.svg" loading="lazy"/>
 								<span class="path-divider-small">/</span>
 								<span class="file-path">{{pathS}}...</span>
-							</a>
+							</button>
 						</div>
 					{{/if}}
 				{{/if}}
@@ -85,10 +91,10 @@
 				{{#partial fileLink}}
 					<div class="file-item file-item-{{type}}">
 						{{#if type === 'directory'}}
-							<a on-click="@this.push('path', name)">
+							<button class="disable-button-styles" on-click="@this.push('path', name)">
 								<img width="20" height="20" src="{{@shared.assetsHost}}/img/icons/folder.svg" loading="lazy"/>
 								/{{~/type}}/{{~/name}}@{{~/sharedVersion}}/<span class="file-path">{{pathS}}{{name}}</span>
-							</a>
+							</button>
 						{{else}}
 							<a target="_blank" rel="noopener noreferrer" href="https://cdn.jsdelivr.net/{{~/type}}/{{~/name}}@{{~/sharedVersion}}/{{pathS}}{{name}}">
 								<img width="20" height="20" src="{{@shared.assetsHost}}/img/icons/file.svg" loading="lazy"/>
@@ -126,7 +132,11 @@
 
 							<label for="{{name}}"
 								on-click="@this.toggleCollectionFile('/' + pathS + name)"
-								as-tooltip="'Add to collection'">
+								on-keydown="@this.handleLabelKeydown(event, '/' + pathS + name)"
+								as-tooltip="'Add to collection'"
+								role="button"
+								aria-pressed="{{@this.getCollectionIndex(~/collection, ~/type, ~/name, ~/sharedVersion, '/' + pathS + name) !== -1}}"
+								tabindex="0">
 							</label>
 						</div>
 					</div>
@@ -149,9 +159,9 @@
 		{{#if _.listFiles(~/files, path).length > filesLimit}}
 			<div class="show-more-toggle">
 				{{#if showMoreFiles}}
-					<a on-click="@this.toggleShowMoreFiles()"><i class="fa fa-angle-up" aria-hidden="true"></i> Show first 10</a>
+					<button class="disable-button-styles" on-click="@this.toggleShowMoreFiles()"><i class="fa fa-angle-up" aria-hidden="true"></i> Show first 10</button>
 				{{else}}
-					<a on-click="@this.toggleShowMoreFiles()"><i class="fa fa-angle-down" aria-hidden="true"></i> Show all</a>
+					<button class="disable-button-styles" on-click="@this.toggleShowMoreFiles()"><i class="fa fa-angle-down" aria-hidden="true"></i> Show all</button>
 				{{/if}}
 			</div>
 		{{/if}}
@@ -339,6 +349,13 @@
 			}
 
 			return Object.assign({ path: file }, f);
+		},
+		handleLabelKeydown (e, path) {
+			if (e.event.key === 'Enter' || e.event.key === ' ') {
+				e.event.preventDefault();
+				e.event.stopPropagation();
+				this.toggleCollectionFile(path);
+			}
 		},
 		toggleCollectionFile (file) {
 			let type = this.get('type');


### PR DESCRIPTION
Closes #685

I changed some anchor tags which didn't have href to button. In my testing there wasn't any issues and tabindex was working properly but I'm not sure if there was an explicit reason for the anchor instead of button. We can add event listeners to anchors to simulate button if necessary.